### PR TITLE
Add traits IntoAscii* to replace (Owned)AsciiCast

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_script:
 script:
   - |
     travis-cargo build &&
-    travis-cargo test &&
+    travis-cargo --skip 1.1.0 test &&
     travis-cargo --only stable doc
 
 after_success:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ use std::ascii::AsciiExt;
 
 pub use ascii::{Ascii, IntoAscii, IntoAsciiError};
 pub use ascii_string::{AsciiString, IntoAsciiString};
-pub use ascii_str::AsciiStr;
+pub use ascii_str::{AsciiStr, AsAsciiStr, AsMutAsciiStr, AsAsciiStrError};
 
 /// Trait for converting into an ascii type.
 pub trait AsciiCast<'a>: AsciiExt {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ mod ascii_str;
 use std::borrow::Borrow;
 use std::ascii::AsciiExt;
 
-pub use ascii::Ascii;
+pub use ascii::{Ascii, IntoAscii, IntoAsciiError};
 pub use ascii_string::AsciiString;
 pub use ascii_str::AsciiStr;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,6 @@
 
 //! Operations on ASCII strings and characters
 
-#![cfg_attr(feature = "unstable", feature(ascii))]
-
 mod ascii;
 mod ascii_string;
 mod ascii_str;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ use std::borrow::Borrow;
 use std::ascii::AsciiExt;
 
 pub use ascii::{Ascii, IntoAscii, IntoAsciiError};
-pub use ascii_string::AsciiString;
+pub use ascii_string::{AsciiString, IntoAsciiString};
 pub use ascii_str::AsciiStr;
 
 /// Trait for converting into an ascii type.


### PR DESCRIPTION
`AsciiCast` has un-rustic names, and doesn't work well for `Ascii` (see first commit)

Another issue is that the traits aren't implemented for their target type,which breaks the pattern `fn foo<B:Into<Bar>>(b: B)`.
Hopefully [`AsciiExt` gets stabilized](https://github.com/rust-lang/rust/issues/27809) soon.
(Then this could be used by `AsciiString.push()`)

`IntoAsciiStr` / The third commit is unfinished, just cherry-pick the first two if I don't finish it.

I haven't removed changed anything, so this is not a breaking change. The idea is to make a minor release, and then remove (Owned)AsciiCast, `Ascii::from_byte()` and more later.