### PR TITLE
Add tormol to the list of authors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@
 name = "ascii"
 version = "0.6.0"
 authors = ["Thomas Bahn <thomas@thomas-bahn.net>",
+           "Torbjørn Birch Moltu <t.b.moltu@lyse.net>",
            "Simon Sapin <simon.sapin@exyr.org>"]
 
 description = "`Ascii` type and related functionality, previously in `std::ascii`."


### PR DESCRIPTION
He contributed significantly to the library, in particular the `no_std` feature and the conversion traits.

@tormol: Do you want to be listed in the authors list?