### PR TITLE
Add methods for core-only feature

### DIFF
--- a/src/ascii_str.rs
+++ b/src/ascii_str.rs
@@ -166,6 +166,35 @@ impl AsciiStr {
                           .rev().take_while(|a| a.is_whitespace() ).count();
         &self[..self.len()-trimmed]
     }
+
+    /// Checks that two strings are an ASCII case-insensitive match.
+    ///
+    /// Same as `to_ascii_lowercase(a) == to_ascii_lowercase(b)`, but without allocating and copying
+    /// temporary strings.
+    #[inline]
+    #[cfg(feature = "no_std")]
+    pub fn eq_ignore_ascii_case(&self, other: &Self) -> bool {
+        self.len() == other.len() &&
+            self.slice.iter().zip(other.slice.iter()).all(|(a, b)| a.eq_ignore_ascii_case(b))
+    }
+
+    /// Converts the ASCII string slice to its ASCII upper case equivalent in-place.
+    #[inline]
+    #[cfg(feature = "no_std")]
+    pub fn make_ascii_uppercase(&mut self) {
+        for ascii in &mut self.slice {
+            ascii.make_ascii_uppercase();
+        }
+    }
+
+    /// Converts the ASCII string slice to its ASCII lower case equivalent in-place.
+    #[inline]
+    #[cfg(feature = "no_std")]
+    pub fn make_ascii_lowercase(&mut self) {
+        for ascii in &mut self.slice {
+            ascii.make_ascii_lowercase();
+        }
+    }
 }
 
 impl PartialEq<str> for AsciiStr {
@@ -346,6 +375,12 @@ impl AsAsciiStrError {
     /// It is the maximum index such that `from_ascii(input[..index])` would return `Ok(_)`.
     pub fn valid_up_to(self) -> usize {
         self.0
+    }
+
+    /// Returns a description for this error, like `std::error::Error::description`.
+    #[cfg(feature = "no_std")]
+    pub fn description(&self) -> &'static str {
+        "one or more bytes are not ASCII"
     }
 }
 impl fmt::Display for AsAsciiStrError {

--- a/src/case_map.rs
+++ b/src/case_map.rs
@@ -1,0 +1,45 @@
+pub static ASCII_LOWERCASE_MAP: [u8; 128] = [
+    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+    0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+    0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+    0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+    b' ', b'!', b'"', b'#', b'$', b'%', b'&', b'\'',
+    b'(', b')', b'*', b'+', b',', b'-', b'.', b'/',
+    b'0', b'1', b'2', b'3', b'4', b'5', b'6', b'7',
+    b'8', b'9', b':', b';', b'<', b'=', b'>', b'?',
+    b'@',
+
+          b'a', b'b', b'c', b'd', b'e', b'f', b'g',
+    b'h', b'i', b'j', b'k', b'l', b'm', b'n', b'o',
+    b'p', b'q', b'r', b's', b't', b'u', b'v', b'w',
+    b'x', b'y', b'z',
+
+                      b'[', b'\\', b']', b'^', b'_',
+    b'`', b'a', b'b', b'c', b'd', b'e', b'f', b'g',
+    b'h', b'i', b'j', b'k', b'l', b'm', b'n', b'o',
+    b'p', b'q', b'r', b's', b't', b'u', b'v', b'w',
+    b'x', b'y', b'z', b'{', b'|', b'}', b'~', 0x7f,
+];
+
+pub static ASCII_UPPERCASE_MAP: [u8; 128] = [
+    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+    0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+    0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+    0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+    b' ', b'!', b'"', b'#', b'$', b'%', b'&', b'\'',
+    b'(', b')', b'*', b'+', b',', b'-', b'.', b'/',
+    b'0', b'1', b'2', b'3', b'4', b'5', b'6', b'7',
+    b'8', b'9', b':', b';', b'<', b'=', b'>', b'?',
+    b'@', b'A', b'B', b'C', b'D', b'E', b'F', b'G',
+    b'H', b'I', b'J', b'K', b'L', b'M', b'N', b'O',
+    b'P', b'Q', b'R', b'S', b'T', b'U', b'V', b'W',
+    b'X', b'Y', b'Z', b'[', b'\\', b']', b'^', b'_',
+    b'`',
+
+          b'A', b'B', b'C', b'D', b'E', b'F', b'G',
+    b'H', b'I', b'J', b'K', b'L', b'M', b'N', b'O',
+    b'P', b'Q', b'R', b'S', b'T', b'U', b'V', b'W',
+    b'X', b'Y', b'Z',
+
+                      b'{', b'|', b'}', b'~', 0x7f,
+];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,8 @@
 
 #![cfg_attr(feature = "no_std", no_std)]
 
+#[cfg(feature = "no_std")]
+mod case_map;
 mod ascii_char;
 mod ascii_str;
 #[cfg(not(feature = "no_std"))]


### PR DESCRIPTION
This is a implementation for #24.

There are remaining tasks:
- [ ] Add tests
- [ ] Compare `ASCII_{LOWER,UPPER}CASE_MAP` to a simple `if` expression.