### PR TITLE
Replace the `no_std` feature with the `std` feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,16 +16,16 @@ script:
   - |
     travis-cargo --skip 1.6.0 build &&
     travis-cargo --skip 1.6.0 test &&
-    travis-cargo build -- --features=no_std &&
-    travis-cargo test -- --features=no_std
+    travis-cargo build -- --no-default-features &&
+    travis-cargo test -- --no-default-features
 
 after_success:
   - |
     if [ "$TRAVIS_RUST_VERSION" == "stable" ]; then
-        travis-cargo doc -- --features=no_std &&
-        mv target/doc target/doc_no_std &&
+        travis-cargo doc -- --no-default-features &&
+        mv target/doc target/doc_core &&
         travis-cargo doc &&
-        mv target/doc_no_std target/doc/no_std &&
+        mv target/doc_core target/doc/core &&
         travis-cargo doc-upload
     fi
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,5 @@ license = "Apache-2.0 / MIT"
 repository = "https://github.com/tomprogrammer/rust-ascii"
 
 [features]
-no_std = []
+default = ["std"]
+std = []

--- a/README.md
+++ b/README.md
@@ -1,29 +1,47 @@
 # ascii
 
-A library that provides ASCII-only string and character types, equivalent to the `char`, `str` and
-`String` types in the standard library.
+A library that provides ASCII-only string and character types, equivalent to the
+`char`, `str` and `String` types in the standard library.
 
 Types and conversion traits are described in the
-[Documentation](https://tomprogrammer.github.io/rust-ascii/ascii/index.html)
+[Documentation](https://tomprogrammer.github.io/rust-ascii/ascii/index.html).
+
+You can include this crate in your cargo project by adding it to the
+dependencies section in `Cargo.toml`:
+```toml
+[dependencies]
+ascii = "0.8"
+```
 
 # Using ascii without libstd
 
-Most of `AsciiChar` and `AsciiStr` can be used without `std` by enabling the feature `no_std`.  
-The owned string type `AsciiString` and the conversion trait `IntoAsciiString` as well as all methods referring to these types are unavailable.  
-Because libcore doesn't have `AsciiExt` and `Error`, most of their methods are implemented directly:
+Most of `AsciiChar` and `AsciiStr` can be used without `std` by disabling the
+default features. The owned string type `AsciiString` and the conversion trait
+`IntoAsciiString` as well as all methods referring to these types are
+unavailable. Because libcore doesn't have `AsciiExt` and `Error`, most of their
+methods are implemented directly:
 * `Ascii{Char,Str}::eq_ignore_ascii_case()`
 * `AsciiChar::to_ascii_{upper,lower}case()`
 * `AsciiStr::make_ascii_{upper,lower}case()`
 * `{ToAsciiChar,AsAsciiStr}Error::description()`
 
+To use the `ascii` crate in `core`-only mode in your cargo project just add the
+following dependency declaration in `Cargo.toml`:
+```toml
+[dependencies]
+ascii = { version = "0.8", default-features = false }
+```
+
 # Requirements
 
-The `ascii` library requires rustc 1.9.0 or greater, due to the
-[stabilization of `AsciiExt`](https://github.com/rust-lang/rust/pull/32804). Using the `no_std`
-feature lowers this requirement to rustc 1.6.0 or greater.
+The `ascii` library requires rustc 1.9.0 or greater, due to
+the [stabilization of `AsciiExt`](https://github.com/rust-lang/rust/pull/32804).
+Using only `core` instead of `std` in your project lowers this requirement to
+rustc 1.6.0 or greater.
 
 # History
 
-This packages included the Ascii types that were removed from the Rust standard library by the
-2014-12 [reform of the `std::ascii` module] (https://github.com/rust-lang/rfcs/pull/486). The API
-changed significantly since then.
+This package included the Ascii types that were removed from the Rust standard
+library by the 2014-12 [reform of the `std::ascii` module]
+(https://github.com/rust-lang/rfcs/pull/486). The API changed significantly
+since then.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -8,6 +8,7 @@ Unreleased
   * `AsciiChar::to_ascii_{upper,lower}case()`
   * `AsciiStr::make_ascii_{upper,lower}case()`
   * `{ToAsciiChar,AsAsciiStr}Error::description()`
+* Replace the `no_std` feature with the additive `std` feature, which is part of the default features. (Issue #29)
 
 Version 0.7.1 (2016-08-15)
 ==========================

--- a/src/ascii_char.rs
+++ b/src/ascii_char.rs
@@ -3,9 +3,9 @@ extern crate core;
 use self::core::mem::transmute;
 use self::core::cmp::Ordering;
 use self::core::{fmt, char};
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 use std::error::Error;
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 use std::ascii::AsciiExt;
 
 #[allow(non_camel_case_types)]
@@ -473,7 +473,7 @@ impl AsciiChar {
         }}
     }
 
-    #[cfg(feature = "no_std")]
+    #[cfg(not(feature = "std"))]
     /// Maps letters `a`...`z` to `A`...`Z` and returns everything else unchanged.
     ///
     /// A replacement for `AsciiExt::to_ascii_uppercase()`.
@@ -484,7 +484,7 @@ impl AsciiChar {
         }}
     }
 
-    #[cfg(feature = "no_std")]
+    #[cfg(not(feature = "std"))]
     /// Maps letters `A`...`Z` to `a`...`z` and returns everything else unchanged.
     ///
     /// A replacement for `AsciiExt::to_ascii_lowercase()`.
@@ -495,7 +495,7 @@ impl AsciiChar {
         }}
     }
 
-    #[cfg(feature = "no_std")]
+    #[cfg(not(feature = "std"))]
     /// Compares two characters case-insensitively.
     ///
     /// A replacement for `AsciiExt::eq_ignore_ascii_case()`.
@@ -516,7 +516,7 @@ impl fmt::Debug for AsciiChar {
      }
 }
 
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 impl AsciiExt for AsciiChar {
     type Owned = AsciiChar;
 
@@ -585,7 +585,7 @@ pub struct ToAsciiCharError(());
 
 const ERRORMSG_CHAR: &'static str = "not an ASCII character";
 
-#[cfg(feature = "no_std")]
+#[cfg(not(feature = "std"))]
 impl ToAsciiCharError {
     /// Returns a description for this error, like `std::error::Error::description`.
     pub fn description(&self) -> &'static str {
@@ -605,7 +605,7 @@ impl fmt::Display for ToAsciiCharError {
     }
 }
 
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 impl Error for ToAsciiCharError {
     fn description(&self) -> &'static str {
         ERRORMSG_CHAR
@@ -658,7 +658,7 @@ impl ToAsciiChar for char {
 mod tests {
     use super::{AsciiChar, ToAsciiChar, ToAsciiCharError};
     use AsciiChar::*;
-    #[cfg(not(feature = "no_std"))]
+    #[cfg(feature = "std")]
     use std::ascii::AsciiExt;
 
     #[test]
@@ -718,7 +718,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(feature = "no_std"))]
+    #[cfg(feature = "std")]
     fn fmt_ascii() {
         assert_eq!(format!("{}", t), "t");
         assert_eq!(format!("{:?}", t), "'t'");

--- a/src/ascii_str.rs
+++ b/src/ascii_str.rs
@@ -2,13 +2,13 @@ extern crate core;
 
 use self::core::{fmt, mem};
 use self::core::ops::{Index, IndexMut, Range, RangeTo, RangeFrom, RangeFull};
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 use std::error::Error;
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 use std::ascii::AsciiExt;
 
 use ascii_char::AsciiChar;
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 use ascii_string::AsciiString;
 
 /// AsciiStr represents a byte or string slice that only contains ASCII characters.
@@ -66,8 +66,8 @@ impl AsciiStr {
         self.as_mut_slice().as_mut_ptr()
     }
 
-    #[cfg(not(feature = "no_std"))]
     /// Copies the content of this `AsciiStr` into an owned `AsciiString`.
+    #[cfg(feature = "std")]
     pub fn to_ascii_string(&self) -> AsciiString {
         AsciiString::from(self.slice.to_vec())
     }
@@ -167,29 +167,29 @@ impl AsciiStr {
         &self[..self.len()-trimmed]
     }
 
-    #[cfg(feature = "no_std")]
     /// Compares two strings case-insensitively.
     ///
     /// A replacement for `AsciiExt::eq_ignore_ascii_case()`.
+    #[cfg(not(feature = "std"))]
     pub fn eq_ignore_ascii_case(&self, other: &Self) -> bool {
         self.len() == other.len() &&
         self.slice.iter().zip(other.slice.iter()).all(|(a, b)| a.eq_ignore_ascii_case(b) )
     }
 
-    #[cfg(feature = "no_std")]
     /// Replaces lowercase letters with their uppercase equivalent.
     ///
     /// A replacement for `AsciiExt::make_ascii_uppercase()`.
+    #[cfg(not(feature = "std"))]
     pub fn make_ascii_uppercase(&mut self) {
         for a in &mut self.slice {
             *a = a.to_ascii_uppercase();
         }
     }
 
-    #[cfg(feature = "no_std")]
     /// Replaces uppercase letters with their lowercase equivalent.
     ///
     /// A replacement for `AsciiExt::make_ascii_lowercase()`.
+    #[cfg(not(feature = "std"))]
     pub fn make_ascii_lowercase(&mut self) {
         for a in &mut self.slice {
             *a = a.to_ascii_lowercase();
@@ -209,7 +209,7 @@ impl PartialEq<AsciiStr> for str {
     }
 }
 
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 impl ToOwned for AsciiStr {
     type Owned = AsciiString;
 
@@ -254,7 +254,7 @@ impl<'a> From<&'a mut [AsciiChar]> for &'a mut AsciiStr {
         unsafe{ mem::transmute(slice) }
     }
 }
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 impl From<Box<[AsciiChar]>> for Box<AsciiStr> {
     fn from(owned: Box<[AsciiChar]>) -> Box<AsciiStr> {
         unsafe{ mem::transmute(owned) }
@@ -273,7 +273,7 @@ macro_rules! impl_into {
                 unsafe{ mem::transmute(slice) }
             }
         }
-        #[cfg(not(feature = "no_std"))]
+        #[cfg(feature = "std")]
         impl From<Box<AsciiStr>> for Box<$wider> {
             fn from(owned: Box<AsciiStr>) -> Box<$wider> {
                 unsafe{ mem::transmute(owned) }
@@ -323,7 +323,7 @@ impl_index! { AsciiStr, RangeTo<usize>, AsciiStr }
 impl_index! { AsciiStr, RangeFrom<usize>, AsciiStr }
 impl_index! { AsciiStr, RangeFull, AsciiStr }
 
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 impl AsciiExt for AsciiStr {
     type Owned = AsciiString;
 
@@ -378,7 +378,7 @@ impl AsAsciiStrError {
     pub fn valid_up_to(self) -> usize {
         self.0
     }
-    #[cfg(feature = "no_std")]
+    #[cfg(not(feature = "std"))]
     /// Returns a description for this error, like `std::error::Error::description`.
     pub fn description(&self) -> &'static str {
         ERRORMSG_STR
@@ -389,7 +389,7 @@ impl fmt::Display for AsAsciiStrError {
         write!(fmtr, "the byte at index {} is not ASCII", self.0)
     }
 }
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 impl Error for AsAsciiStrError {
     fn description(&self) -> &'static str {
         ERRORMSG_STR
@@ -495,7 +495,7 @@ impl AsMutAsciiStr for str {
 mod tests {
     use AsciiChar;
     use super::{AsciiStr, AsAsciiStr, AsMutAsciiStr, AsAsciiStrError};
-    #[cfg(not(feature = "no_std"))]
+    #[cfg(feature = "std")]
     use std::ascii::AsciiExt;
 
     #[test]
@@ -511,7 +511,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(feature = "no_std"))]
+    #[cfg(feature = "std")]
     fn as_ascii_str() {
         macro_rules! err {{$i:expr} => {Err(AsAsciiStrError($i))}}
         let mut s: String = "abčd".to_string();
@@ -564,7 +564,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(feature = "no_std"))]
+    #[cfg(feature = "std")]
     fn fmt_ascii_str() {
         let s = "abc".as_ascii_str().unwrap();
         assert_eq!(format!("{}", s), "abc".to_string());

--- a/src/ascii_string.rs
+++ b/src/ascii_string.rs
@@ -110,8 +110,9 @@ impl AsciiString {
     /// assert_eq!(foo.as_str(), "foo");
     /// assert_eq!(err.into_source(), "Ŋ");
     /// ```
-    pub fn from_ascii<B: Into<Vec<u8>> + AsRef<[u8]>>
-    (bytes: B) -> Result<AsciiString, FromAsciiError<B>> {
+    pub fn from_ascii<B>(bytes: B) -> Result<AsciiString, FromAsciiError<B>>
+        where B: Into<Vec<u8>> + AsRef<[u8]>
+    {
         unsafe{ match bytes.as_ref().as_ascii_str() {
             Ok(_) => Ok(AsciiString::from_ascii_unchecked(bytes)),
             Err(e) => Err(FromAsciiError{error: e,  owner: bytes}),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,31 +11,32 @@
 //! A library that provides ASCII-only string and character types, equivalent to the `char`, `str` and
 //! `String` types in the standard library.
 //!
-#![cfg_attr(not(feature = "no_std"), doc="[The documentation for `#[no_std]` mode is here](https://tomprogrammer.github.io/rust-ascii/no_std/ascii/index.html).")]
-#![cfg_attr(feature = "no_std", doc="This is the documentation for `#[no_std]` mode.")]
+#![cfg_attr(feature = "std", doc="[The documentation for the `core` mode is here](https://tomprogrammer.github.io/rust-ascii/core/ascii/index.html).")]
+#![cfg_attr(not(feature = "std"), doc="This is the documentation for `core` mode.")]
+//! Please refer to the readme file to learn about the different feature modes of this crate.
 //!
 //! # Requirements
 //!
 //! The `ascii` library requires rustc 1.9.0 or greater, due to the [stabilization of
-//! `AsciiExt`](https://github.com/rust-lang/rust/pull/32804). Using the `no_std` feature lowers
-//! this requirement to rustc 1.6.0 or greater.
+//! `AsciiExt`](https://github.com/rust-lang/rust/pull/32804). Using only `core` instead of `std` in
+//! your project lowers this requirement to rustc 1.6.0 or greater.
 //!
 //! # History
 //!
-//! This packages included the Ascii types that were removed from the Rust standard library by the
+//! This package included the Ascii types that were removed from the Rust standard library by the
 //! 2014-12 [reform of the `std::ascii` module](https://github.com/rust-lang/rfcs/pull/486). The
 //! API changed significantly since then.
 
-#![cfg_attr(feature = "no_std", no_std)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 mod free_functions;
 mod ascii_char;
 mod ascii_str;
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 mod ascii_string;
 
 pub use free_functions::{caret_encode, caret_decode};
 pub use ascii_char::{AsciiChar, ToAsciiChar, ToAsciiCharError};
 pub use ascii_str::{AsciiStr, AsAsciiStr, AsMutAsciiStr, AsAsciiStrError};
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 pub use ascii_string::{AsciiString, IntoAsciiString, FromAsciiError};

--- a/tests.rs
+++ b/tests.rs
@@ -1,11 +1,11 @@
 extern crate ascii;
 
 use ascii::{AsciiChar, AsciiStr, AsAsciiStr};
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 use ascii::{AsciiString, IntoAsciiString};
 
 #[test]
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 fn ascii_vec() {
     let test = b"( ;";
     let a = AsciiStr::from_ascii(test).unwrap();
@@ -28,7 +28,7 @@ fn to_ascii() {
 }
 
 #[test]
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 fn into_ascii() {
     let arr = [AsciiChar::ParenOpen, AsciiChar::Space, AsciiChar::Semicolon];
     let v = AsciiString::from(arr.to_vec());
@@ -44,7 +44,7 @@ fn into_ascii() {
 }
 
 #[test]
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 fn compare_ascii_string_ascii_str() {
     let v = b"abc";
     let ascii_string = AsciiString::from_ascii(&v[..]).unwrap();
@@ -54,7 +54,7 @@ fn compare_ascii_string_ascii_str() {
 }
 
 #[test]
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 fn compare_ascii_string_string() {
     let v = b"abc";
     let string = String::from_utf8(v.to_vec()).unwrap();
@@ -64,7 +64,7 @@ fn compare_ascii_string_string() {
 }
 
 #[test]
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 fn compare_ascii_str_string() {
     let v = b"abc";
     let string = String::from_utf8(v.to_vec()).unwrap();
@@ -74,7 +74,7 @@ fn compare_ascii_str_string() {
 }
 
 #[test]
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 fn compare_ascii_string_str() {
     let v = b"abc";
     let sstr = ::std::str::from_utf8(v).unwrap();
@@ -101,7 +101,7 @@ fn compare_ascii_str_slice() {
 }
 
 #[test]
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 fn compare_ascii_string_slice() {
     let b = AsciiString::from_ascii("abc").unwrap();
     let c = AsciiString::from_ascii("ab").unwrap();


### PR DESCRIPTION
Features should be additive as pointed out in issue #29. The feature is called `std` instead of the proposed `use_std`, because it's preferred to call the features same as the crates they enable. (Features and dependencies share a namespace.)

Closes: #29 
