### PR TITLE
Implement `quickcheck::Arbitrary` support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,17 +1,20 @@
-test = [{name = "tests", path = "tests.rs"}]
-
 [package]
-name = "ascii"
-version = "0.8.1"
-authors = ["Thomas Bahn <thomas@thomas-bahn.net>",
-           "Torbjørn Birch Moltu <t.b.moltu@lyse.net>",
-           "Simon Sapin <simon.sapin@exyr.org>"]
-
+authors = ["Thomas Bahn <thomas@thomas-bahn.net>", "Torbjørn Birch Moltu <t.b.moltu@lyse.net>", "Simon Sapin <simon.sapin@exyr.org>"]
 description = "ASCII-only equivalents to `char`, `str` and `String`."
 documentation = "https://tomprogrammer.github.io/rust-ascii/ascii/index.html"
 license = "Apache-2.0 / MIT"
+name = "ascii"
 repository = "https://github.com/tomprogrammer/rust-ascii"
+version = "0.8.1"
+
+[dependencies.quickcheck]
+optional = true
+version = "0.4.1"
 
 [features]
 default = ["std"]
 std = []
+
+[[test]]
+name = "tests"
+path = "tests.rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,9 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+#[cfg(feature = "quickcheck")]
+extern crate quickcheck;
+
 mod free_functions;
 mod ascii_char;
 mod ascii_str;


### PR DESCRIPTION
This commit implements the `Arbitrary` trait for the types `AsciiChar` and `AsciiString` as suggested in #35.