### PR TITLE
Follow Rusts deprecation of AsciiExt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rust:
   - nightly
   - beta
   - stable
-  - 1.6.0
+  - 1.9.0
 
 before_script:
   - |
@@ -14,8 +14,8 @@ before_script:
 
 script:
   - |
-    travis-cargo --skip 1.6.0 build &&
-    travis-cargo --skip 1.6.0 test &&
+    travis-cargo build &&
+    travis-cargo test &&
     travis-cargo build -- --no-default-features &&
     travis-cargo test -- --no-default-features
 

--- a/README.md
+++ b/README.md
@@ -18,12 +18,8 @@ ascii = "0.8"
 Most of `AsciiChar` and `AsciiStr` can be used without `std` by disabling the
 default features. The owned string type `AsciiString` and the conversion trait
 `IntoAsciiString` as well as all methods referring to these types are
-unavailable. Because libcore doesn't have `AsciiExt` and `Error`, most of their
-methods are implemented directly:
-* `Ascii{Char,Str}::eq_ignore_ascii_case()`
-* `AsciiChar::to_ascii_{upper,lower}case()`
-* `AsciiStr::make_ascii_{upper,lower}case()`
-* `{ToAsciiChar,AsAsciiStr}Error::description()`
+unavailable. The `Error` trait is also unavailable, but `description()` is made
+available as an inherent method for `ToAsciiCharError` and `AsAsciiStrError`.
 
 To use the `ascii` crate in `core`-only mode in your cargo project just add the
 following dependency declaration in `Cargo.toml`:

--- a/README.md
+++ b/README.md
@@ -30,10 +30,8 @@ ascii = { version = "0.8", default-features = false }
 
 # Requirements
 
-The `ascii` library requires rustc 1.9.0 or greater, due to
-the [stabilization of `AsciiExt`](https://github.com/rust-lang/rust/pull/32804).
-Using only `core` instead of `std` in your project lowers this requirement to
-rustc 1.6.0 or greater.
+The minimum supported Rust version is 1.9.0.
+Enabling the quickcheck integration requires Rust 1.20.0.
 
 # History
 

--- a/src/ascii_str.rs
+++ b/src/ascii_str.rs
@@ -740,7 +740,7 @@ mod tests {
         let mut ascii_str_mut: &mut AsciiStr = arr_mut.as_mut().into();
         // Need a second reference to prevent overlapping mutable borrows
         let mut arr_mut_2 = [AsciiChar::B];
-        let mut ascii_str_mut_2: &mut AsciiStr = arr_mut_2.as_mut().into();
+        let ascii_str_mut_2: &mut AsciiStr = arr_mut_2.as_mut().into();
         assert_eq!(generic_mut(&mut ascii_str_mut), Ok(&mut *ascii_str_mut_2));
         assert_eq!(generic_mut(ascii_str_mut), Ok(&mut *ascii_str_mut_2));
     }
@@ -788,8 +788,8 @@ mod tests {
     #[test]
     fn make_ascii_case() {
         let mut bytes = ([b'a', b'@', b'A'], [b'A', b'@', b'a']);
-        let mut a = bytes.0.as_mut_ascii_str().unwrap();
-        let mut b = bytes.1.as_mut_ascii_str().unwrap();
+        let a = bytes.0.as_mut_ascii_str().unwrap();
+        let b = bytes.1.as_mut_ascii_str().unwrap();
         assert!(a.eq_ignore_ascii_case(b));
         assert!(b.eq_ignore_ascii_case(a));
         a.make_ascii_lowercase();
@@ -799,13 +799,15 @@ mod tests {
     }
 
     #[test]
-    #[cfg(features = "std")]
+    #[cfg(feature = "std")]
     fn to_ascii_case() {
-        let mut bytes = ([b'a', b'@', b'A'], [b'A', b'@', b'a']);
-        let mut a = bytes.0.as_mut_ascii_str().unwrap();
-        let mut b = bytes.1.as_mut_ascii_str().unwrap();
+        let bytes = ([b'a', b'@', b'A'], [b'A', b'@', b'a']);
+        let a = bytes.0.as_ascii_str().unwrap();
+        let b = bytes.1.as_ascii_str().unwrap();
         assert_eq!(a.to_ascii_lowercase().as_str(), "a@a");
         assert_eq!(a.to_ascii_uppercase().as_str(), "A@A");
+        assert_eq!(b.to_ascii_lowercase().as_str(), "a@a");
+        assert_eq!(b.to_ascii_uppercase().as_str(), "A@A");
     }
 
     #[test]
@@ -819,8 +821,8 @@ mod tests {
 
     #[test]
     fn chars_iter_mut() {
-        let mut chars = &mut [b'h', b'e', b'l', b'l', b'o', b' ', b'w', b'o', b'r', b'l', b'd', b'\0'];
-        let mut ascii = chars.as_mut_ascii_str().unwrap();
+        let chars = &mut [b'h', b'e', b'l', b'l', b'o', b' ', b'w', b'o', b'r', b'l', b'd', b'\0'];
+        let ascii = chars.as_mut_ascii_str().unwrap();
 
         *ascii.chars_mut().next().unwrap() = AsciiChar::H;
 


### PR DESCRIPTION
`AsciiExt` is being deprecated in Rust 1.26 (which is about to become beta), and replaced by inherent methods.

This pull request follows Rusts footsteps by un-feature-gating the existing replacement methods and adding the remaining (except `is_ascii()`).
The next major release can then remove the `AsciiExt` impls completely.

While the purpose of this crate is to contain things removed from `std::ascii`, I don't see any use case of the trait as a generic bound. Adding a copy of it would count as a separate trait too.

(`Error::description()` is being soft-deprecated / hidden in Rust 1.27, but that method seems kind of useful in `#![no_std]` contexts where `format!()` doesn't work, so I kept the separate documentation and README mention.)