### PR TITLE
Bump quickcheck to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.8.6"
 
 [dependencies.quickcheck]
 optional = true
-version = "0.5"
+version = "0.6"
 
 [features]
 default = ["std"]


### PR DESCRIPTION
The bump to 0.5 haven't been released