### PR TITLE
Misc 3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.9.1"
 
 [dependencies]
 quickcheck = { version = "0.6", optional = true }
-serde = { version = "1.0", optional = true }
+serde = { version = "1.0.25", optional = true }
 serde_test = { version = "1.0", optional = true }
 
 [features]

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -186,8 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2017 Thomas Bahn and contributors
-   Copyright 2014 The Rust Project Developers
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -8,12 +8,13 @@ Types and conversion traits are described in the
 
 You can include this crate in your cargo project by adding it to the
 dependencies section in `Cargo.toml`:
+
 ```toml
 [dependencies]
 ascii = "0.9"
 ```
 
-# Using ascii without libstd
+## Using ascii without libstd
 
 Most of `AsciiChar` and `AsciiStr` can be used without `std` by disabling the
 default features. The owned string type `AsciiString` and the conversion trait
@@ -23,33 +24,34 @@ available as an inherent method for `ToAsciiCharError` and `AsAsciiStrError`.
 
 To use the `ascii` crate in `core`-only mode in your cargo project just add the
 following dependency declaration in `Cargo.toml`:
+
 ```toml
 [dependencies]
 ascii = { version = "0.9", default-features = false }
 ```
 
-# Requirements
+## Requirements
 
 - The minimum supported Rust version is 1.9.0
 - Enabling the quickcheck feature requires Rust 1.12.0
 - Enabling the serde feature requires Rust 1.13.0
 
-# History
+## History
 
 This package included the Ascii types that were removed from the Rust standard
 library by the 2014-12 [reform of the `std::ascii` module](https://github.com/rust-lang/rfcs/pull/486).
 The API changed significantly since then.
 
-# License
+## License
 
 Licensed under either of
 
- * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
- * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+* Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+* MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
 
 at your option.
 
-## Contribution
+### Contribution
 
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any

--- a/src/ascii_char.rs
+++ b/src/ascii_char.rs
@@ -576,6 +576,12 @@ impl AsciiExt for AsciiChar {
     }
 }
 
+impl Default for AsciiChar {
+    fn default() -> AsciiChar {
+        AsciiChar::Null
+    }
+}
+
 macro_rules! impl_into_partial_eq_ord {($wider:ty, $to_wider:expr) => {
     impl From<AsciiChar> for $wider {
         #[inline]

--- a/src/ascii_str.rs
+++ b/src/ascii_str.rs
@@ -250,6 +250,18 @@ impl AsciiStr {
         ascii_string.make_ascii_lowercase();
         ascii_string
     }
+
+    /// Returns the first character if the string is not empty.
+    #[inline]
+    pub fn first(&self) -> Option<AsciiChar> {
+        self.slice.first().cloned()
+    }
+
+    /// Returns the last character if the string is not empty.
+    #[inline]
+    pub fn last(&self) -> Option<AsciiChar> {
+        self.slice.last().cloned()
+    }
 }
 
 impl PartialEq<str> for AsciiStr {

--- a/src/ascii_str.rs
+++ b/src/ascii_str.rs
@@ -264,19 +264,26 @@ impl AsciiStr {
     }
 }
 
-impl PartialEq<str> for AsciiStr {
-    #[inline]
-    fn eq(&self, other: &str) -> bool {
-        self.as_str() == other
-    }
+macro_rules! impl_partial_eq {
+    ($wider: ty) => {
+        impl PartialEq<$wider> for AsciiStr {
+            #[inline]
+            fn eq(&self, other: &$wider) -> bool {
+                <AsciiStr as AsRef<$wider>>::as_ref(self) == other
+            }
+        }
+        impl PartialEq<AsciiStr> for $wider {
+            #[inline]
+            fn eq(&self, other: &AsciiStr) -> bool {
+                self == <AsciiStr as AsRef<$wider>>::as_ref(other)
+            }
+        }
+    };
 }
 
-impl PartialEq<AsciiStr> for str {
-    #[inline]
-    fn eq(&self, other: &AsciiStr) -> bool {
-        other.as_str() == self
-    }
-}
+impl_partial_eq!{str}
+impl_partial_eq!{[u8]}
+impl_partial_eq!{[AsciiChar]}
 
 #[cfg(feature = "std")]
 impl ToOwned for AsciiStr {

--- a/src/ascii_str.rs
+++ b/src/ascii_str.rs
@@ -368,6 +368,19 @@ impl From<Box<[AsciiChar]>> for Box<AsciiStr> {
     }
 }
 
+impl AsRef<AsciiStr> for [AsciiChar] {
+    #[inline]
+    fn as_ref(&self) -> &AsciiStr {
+        self.into()
+    }
+}
+impl AsMut<AsciiStr> for [AsciiChar] {
+    #[inline]
+    fn as_mut(&mut self) -> &mut AsciiStr {
+        self.into()
+    }
+}
+
 macro_rules! impl_into {
     ($wider: ty) => {
         impl<'a> From<&'a AsciiStr> for &'a$wider {

--- a/src/ascii_string.rs
+++ b/src/ascii_string.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(rustfmt, rustfmt_skip)]
 
 use std::{fmt, mem};
-use std::borrow::{Borrow, Cow};
+use std::borrow::{Borrow, BorrowMut, Cow};
 use std::error::Error;
 use std::any::Any;
 use std::str::FromStr;
@@ -418,6 +418,13 @@ impl Borrow<AsciiStr> for AsciiString {
     }
 }
 
+impl BorrowMut<AsciiStr> for AsciiString {
+    #[inline]
+    fn borrow_mut(&mut self) -> &mut AsciiStr {
+        &mut*self
+    }
+}
+
 impl From<Vec<AsciiChar>> for AsciiString {
     #[inline]
     fn from(vec: Vec<AsciiChar>) -> Self {
@@ -474,6 +481,13 @@ impl AsRef<AsciiStr> for AsciiString {
     }
 }
 
+impl AsRef<[AsciiChar]> for AsciiString {
+    #[inline]
+    fn as_ref(&self) -> &[AsciiChar] {
+        &self.vec
+    }
+}
+
 impl AsRef<[u8]> for AsciiString {
     #[inline]
     fn as_ref(&self) -> &[u8] {
@@ -481,10 +495,24 @@ impl AsRef<[u8]> for AsciiString {
     }
 }
 
+impl AsRef<str> for AsciiString {
+    #[inline]
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
 impl AsMut<AsciiStr> for AsciiString {
     #[inline]
     fn as_mut(&mut self) -> &mut AsciiStr {
         &mut *self
+    }
+}
+
+impl AsMut<[AsciiChar]> for AsciiString {
+    #[inline]
+    fn as_mut(&mut self) -> &mut [AsciiChar] {
+        &mut self.vec
     }
 }
 

--- a/tests.rs
+++ b/tests.rs
@@ -111,3 +111,31 @@ fn compare_ascii_string_slice() {
     assert_eq!(&b[..2], &c[..]);
     assert_eq!(c[1].as_char(), 'b');
 }
+
+#[test]
+#[cfg(feature = "std")]
+fn extend_from_iterator() {
+    use ::std::borrow::Cow;
+
+    let abc = "abc".as_ascii_str().unwrap();
+    let mut s = abc.chars().cloned().collect::<AsciiString>();
+    assert_eq!(s, abc);
+    s.extend(abc);
+    assert_eq!(s, "abcabc");
+
+    let lines = "one\ntwo\nthree".as_ascii_str().unwrap().lines();
+    s.extend(lines);
+    assert_eq!(s, "abcabconetwothree");
+
+    let cows = "ASCII Ascii ascii".as_ascii_str().unwrap()
+        .split(AsciiChar::Space)
+        .map(|case| {
+            if case.chars().all(|a| a.is_uppercase() ) {
+                Cow::from(case)
+            } else {
+                Cow::from(case.to_ascii_uppercase())
+            }
+        });
+    s.extend(cows);
+    assert_eq!(s, "abcabconetwothreeASCIIASCIIASCII");
+}


### PR DESCRIPTION
Seeing #54 reminded me of a bunch of changes I had started on, and motivated me to finish up the non-breaking ones:

* Add `AsciiStr::split()`, `AsciiStr::first()` and `AsciiStr::last()`
* Make `AsciiStr::lines()` iterator double-ended
* Implement `From` conversions between `Cow<AsciiStr>` and `AsciiString` or `&AsciiStr`, and
* Implement creating and `Extend`ing `AsciiString` from `Cow<AsciiStr>`-producing iterators.
* Implement `PartialEq<[u8]>` and `PartialEq<[AsciiChar]>` for `AsciiStr` (in addition to existing `PartialEq<str>`)
* Implement `BorrowMut<AsciiStr>`,  `AsMut<[AsciiChar]>`, `AsRef<[AsciiChar]>` and `AsRef<str>` for `AsciiString`
* Implement `AsRef<AsciiStr>` and `AsMut<AsciiStr>` for `[AsciiChar]`
* Implement `Default` for `AsciiChar`