### PR TITLE
Implement conversion methods on {CStr, CString}

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,6 +1,8 @@
 Unreleased
 ==========
 * Implement the `std::ops::AddAssign` trait for `AsciiString`.
+* Implement the `IntoAsciiString` trait for `std::ffi::CStr` and `std::ffi::CString` types,
+  and implemented the `AsAsciiStr` trait for `std::ffi::CStr` type.
 
 Version 0.9.1 (2018-09-12)
 ==========================

--- a/src/ascii_str.rs
+++ b/src/ascii_str.rs
@@ -4,7 +4,7 @@
 // which would call the inherent methods if AsciiExt wasn't in scope.
 #![cfg_attr(feature = "std", allow(deprecated))]
 
-use core::{fmt, mem};
+use core::fmt;
 use core::ops::{Index, IndexMut, Range, RangeTo, RangeFrom, RangeFull};
 use core::slice::{Iter, IterMut};
 #[cfg(feature = "std")]
@@ -36,15 +36,13 @@ impl AsciiStr {
     /// Converts `&self` to a `&str` slice.
     #[inline]
     pub fn as_str(&self) -> &str {
-        let ptr = self as *const AsciiStr as *const str;
-        unsafe { &*ptr }
+        From::from(self)
     }
 
     /// Converts `&self` into a byte slice.
     #[inline]
     pub fn as_bytes(&self) -> &[u8] {
-        let ptr = self as *const AsciiStr as *const [u8];
-        unsafe { &*ptr }
+        From::from(self)
     }
 
     /// Returns the entire string as slice of `AsciiChar`s.
@@ -342,7 +340,7 @@ impl AsMut<[AsciiChar]> for AsciiStr {
 impl Default for &'static AsciiStr {
     #[inline]
     fn default() -> &'static AsciiStr {
-        unsafe { "".as_ascii_str_unchecked() }
+        From::from(&[] as &[AsciiChar])
     }
 }
 impl<'a> From<&'a [AsciiChar]> for &'a AsciiStr {
@@ -432,16 +430,14 @@ macro_rules! impl_index {
 
             #[inline]
             fn index(&self, index: $idx) -> &AsciiStr {
-                let ptr = &self.slice[index] as *const [AsciiChar] as *const AsciiStr;
-                unsafe { &* ptr }
+                self.slice[index].as_ref()
             }
         }
 
         impl IndexMut<$idx> for AsciiStr {
             #[inline]
             fn index_mut(&mut self, index: $idx) -> &mut AsciiStr {
-                let ptr = &mut self.slice[index] as *mut [AsciiChar] as *mut AsciiStr;
-                unsafe { &mut *ptr }
+                self.slice[index].as_mut()
             }
         }
     }
@@ -457,14 +453,14 @@ impl Index<usize> for AsciiStr {
 
     #[inline]
     fn index(&self, index: usize) -> &AsciiChar {
-        unsafe { mem::transmute(&self.slice[index]) }
+        &self.slice[index]
     }
 }
 
 impl IndexMut<usize> for AsciiStr {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut AsciiChar {
-        unsafe { mem::transmute(&mut self.slice[index]) }
+        &mut self.slice[index]
     }
 }
 

--- a/src/ascii_str.rs
+++ b/src/ascii_str.rs
@@ -840,6 +840,19 @@ mod tests {
         assert_eq!(generic(&mut "A"), Ok(ascii_str));
     }
 
+    #[cfg(feature = "std")]
+    #[test]
+    fn cstring_as_ascii_str() {
+        use std::ffi::{CStr, CString};
+        fn generic<C: AsAsciiStr + ?Sized>(c: &C) -> Result<&AsciiStr, AsAsciiStrError> {
+            c.as_ascii_str()
+        }
+        let arr = [AsciiChar::A];
+        let ascii_str: &AsciiStr = arr.as_ref().into();
+        let cstr = CString::new("A").unwrap();
+        assert_eq!(generic(&*cstr), Ok(ascii_str));
+    }
+
     #[test]
     fn generic_as_mut_ascii_str() {
         fn generic_mut<C: AsMutAsciiStr + ?Sized>(

--- a/src/ascii_str.rs
+++ b/src/ascii_str.rs
@@ -808,6 +808,7 @@ impl AsMutAsciiStr for str {
 }
 
 /// Note that the trailing null byte will be removed in the conversion.
+#[cfg(feature = "std")]
 impl AsAsciiStr for CStr {
     #[inline]
     fn as_ascii_str(&self) -> Result<&AsciiStr, AsAsciiStrError> {

--- a/src/ascii_str.rs
+++ b/src/ascii_str.rs
@@ -843,7 +843,7 @@ mod tests {
     #[cfg(feature = "std")]
     #[test]
     fn cstring_as_ascii_str() {
-        use std::ffi::{CStr, CString};
+        use std::ffi::CString;
         fn generic<C: AsAsciiStr + ?Sized>(c: &C) -> Result<&AsciiStr, AsAsciiStrError> {
             c.as_ascii_str()
         }

--- a/src/ascii_string.rs
+++ b/src/ascii_string.rs
@@ -904,10 +904,16 @@ mod tests {
     #[test]
     fn from_cstring() {
         let cstring = CString::new("baz").unwrap();
-        let ascii_str = cstring.into_ascii_string().unwrap();
+        let ascii_str = cstring.clone().into_ascii_string().unwrap();
         let expected_chars = &[AsciiChar::b, AsciiChar::a, AsciiChar::z];
         assert_eq!(ascii_str.len(), 3);
         assert_eq!(ascii_str.as_slice(), expected_chars);
+
+        let ascii_str_unchecked = unsafe {
+            cstring.into_ascii_string_unchecked()
+        };
+        assert_eq!(ascii_str_unchecked.len(), 3);
+        assert_eq!(ascii_str_unchecked.as_slice(), expected_chars);
 
         let sparkle_heart_bytes = vec![240u8, 159, 146, 150];
         let cstring = CString::new(sparkle_heart_bytes).unwrap();

--- a/src/ascii_string.rs
+++ b/src/ascii_string.rs
@@ -796,7 +796,8 @@ impl IntoAsciiString for CString {
                 }
             })
             .map(|mut s| {
-                s.pop();
+                let _nul = s.pop();
+                debug_assert_eq!(_nul, Some(AsciiChar::Null));
                 s
             })
     }
@@ -818,7 +819,8 @@ impl<'a> IntoAsciiString for &'a CStr {
                 }
             })
             .map(|mut s| {
-                s.pop();
+                let _nul = s.pop();
+                debug_assert_eq!(_nul, Some(AsciiChar::Null));
                 s
             })
     }

--- a/src/ascii_string.rs
+++ b/src/ascii_string.rs
@@ -880,7 +880,7 @@ mod tests {
         let cstring = CString::new("baz").unwrap();
         let ascii_str = cstring.into_ascii_string().unwrap();
         let expected_chars = &[AsciiChar::b, AsciiChar::a, AsciiChar::z];
-        assert!(ascii_str.len() == 3);
+        assert_eq!(ascii_str.len(), 3);
         assert_eq!(ascii_str.as_slice(), expected_chars);
 
         let sparkle_heart_bytes = vec![240u8, 159, 146, 150];

--- a/src/ascii_string.rs
+++ b/src/ascii_string.rs
@@ -743,7 +743,7 @@ impl IntoAsciiString for Vec<AsciiChar> {
 
 macro_rules! impl_into_ascii_string {
     ('a, $wider:ty) => {
-        impl<'a> IntoAsciiString for &'a $wider {
+        impl<'a> IntoAsciiString for $wider {
             #[inline]
             unsafe fn into_ascii_string_unchecked(self) -> AsciiString {
                 AsciiString::from_ascii_unchecked(self)
@@ -772,9 +772,9 @@ macro_rules! impl_into_ascii_string {
 }
 
 impl_into_ascii_string!{Vec<u8>}
-impl_into_ascii_string!{'a, [u8]}
+impl_into_ascii_string!{'a, &'a [u8]}
 impl_into_ascii_string!{String}
-impl_into_ascii_string!{'a, str}
+impl_into_ascii_string!{'a, &'a str}
 
 /// Note that the trailing null byte will be removed in the conversion.
 impl IntoAsciiString for CString {

--- a/src/ascii_string.rs
+++ b/src/ascii_string.rs
@@ -448,6 +448,20 @@ impl Into<Vec<u8>> for AsciiString {
     }
 }
 
+impl<'a> From<&'a AsciiStr> for AsciiString {
+    #[inline]
+    fn from(s: &'a AsciiStr) -> Self {
+        s.to_ascii_string()
+    }
+}
+
+impl<'a> From<&'a [AsciiChar]> for AsciiString {
+    #[inline]
+    fn from(s: &'a [AsciiChar]) -> AsciiString {
+        s.into_iter().map(|c| *c).collect()
+    }
+}
+
 impl Into<String> for AsciiString {
     #[inline]
     fn into(self) -> String {
@@ -719,18 +733,29 @@ pub trait IntoAsciiString: Sized {
     fn into_ascii_string(self) -> Result<AsciiString, FromAsciiError<Self>>;
 }
 
-impl IntoAsciiString for AsciiString {
+impl IntoAsciiString for Vec<AsciiChar> {
     #[inline]
     unsafe fn into_ascii_string_unchecked(self) -> AsciiString {
-        self
+        AsciiString::from(self)
     }
     #[inline]
-    fn into_ascii_string(self) -> Result<Self, FromAsciiError<Self>> {
-        Ok(self)
+    fn into_ascii_string(self) -> Result<AsciiString, FromAsciiError<Self>> {
+        Ok(AsciiString::from(self))
     }
 }
 
-impl IntoAsciiString for Vec<AsciiChar> {
+impl<'a> IntoAsciiString for &'a [AsciiChar] {
+    #[inline]
+    unsafe fn into_ascii_string_unchecked(self) -> AsciiString {
+        AsciiString::from(self)
+    }
+    #[inline]
+    fn into_ascii_string(self) -> Result<AsciiString, FromAsciiError<Self>> {
+        Ok(AsciiString::from(self))
+    }
+}
+
+impl<'a> IntoAsciiString for &'a AsciiStr {
     #[inline]
     unsafe fn into_ascii_string_unchecked(self) -> AsciiString {
         AsciiString::from(self)
@@ -771,6 +796,7 @@ macro_rules! impl_into_ascii_string {
     };
 }
 
+impl_into_ascii_string!{AsciiString}
 impl_into_ascii_string!{Vec<u8>}
 impl_into_ascii_string!{'a, &'a [u8]}
 impl_into_ascii_string!{String}


### PR DESCRIPTION
Originally I wanted to preserve the trailing null byte in the conversions. However, for safety, I left it out in case we added methods later to convert a `&mut CStr` to a `&mut AsciiStr`, otherwise users could have changed the trailing null byte and invalidated safety guarantees. Then, for consistency, I changed the other methods to remove the trailing null byte.