### PR TITLE
1.0 changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,10 @@ rust:
 
 before_script:
   - |
-    pip install 'travis-cargo<0.2' --user &&
-    rustup component add clippy &&
+    pip install 'travis-cargo<0.2' --user || exit 1;
+    if [ "$TRAVIS_RUST_VERSION" == "stable" ]; then
+        rustup component add clippy || exit 1
+    fi
     export PATH=$HOME/.local/bin:$PATH
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rust:
   - nightly
   - beta
   - stable
-  - 1.36.0
+  - 1.33.0
 
 before_script:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rust:
   - nightly
   - beta
   - stable
-  - 1.9.0
+  - 1.36.0
 
 before_script:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ rust:
 before_script:
   - |
     pip install 'travis-cargo<0.2' --user &&
+    rustup component add clippy &&
     export PATH=$HOME/.local/bin:$PATH
 
 script:
@@ -17,6 +18,7 @@ script:
     travis-cargo test -- --no-default-features &&
     travis-cargo test &&
     travis-cargo test -- --all-features &&
+    travis-cargo --only stable clippy -- --all-features &&
     rm Cargo.lock &&
     travis-cargo --only nightly build -- -Z minimal-versions --all-features
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,7 @@ script:
     travis-cargo test &&
     travis-cargo test -- --all-features &&
     rm Cargo.lock &&
-    # no version of quickcheck compiles with -Z minimal-versions, but serde does
-    travis-cargo --only nightly build -- -Z minimal-versions --features 'serde serde-test'
+    travis-cargo --only nightly build -- -Z minimal-versions --all-features
 
 after_success:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,12 @@ before_script:
 
 script:
   - |
-    travis-cargo build &&
+    travis-cargo test -- --no-default-features &&
     travis-cargo test &&
-    travis-cargo build -- --no-default-features &&
-    travis-cargo test -- --no-default-features
+    travis-cargo test -- --all-features &&
+    rm Cargo.lock &&
+    # no version of quickcheck compiles with -Z minimal-versions, but serde does
+    travis-cargo --only nightly build -- -Z minimal-versions --features 'serde serde-test'
 
 after_success:
   - |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ repository = "https://github.com/tomprogrammer/rust-ascii"
 version = "0.9.2"
 
 [dependencies]
-quickcheck = { version = "0.6", optional = true }
 serde = { version = "1.0.25", optional = true }
 serde_test = { version = "1.0", optional = true }
 

--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ ascii = { version = "0.9", default-features = false }
 
 ## Minimum supported Rust version
 
-The minimum supported Rust version for 1.0.\* releases is 1.36.0.
+The minimum Rust version for 1.0.\* releases is 1.33.0.
 Later 1.y.0 releases might require newer Rust versions, but the three most
 recent stable releases at the time of publishing will always be supported.  
-For example this means that if the current stable Rust version is 1.44 when
+For example this means that if the current stable Rust version is 1.38 when
 ascii 1.1.0 is released, then ascii 1.1.* will not require a newer
-Rust version than 1.42.
+Rust version than 1.36.
 
 ## History
 

--- a/README.md
+++ b/README.md
@@ -30,11 +30,14 @@ following dependency declaration in `Cargo.toml`:
 ascii = { version = "0.9", default-features = false }
 ```
 
-## Requirements
+## Minimum supported Rust version
 
-- The minimum supported Rust version is 1.9.0
-- Enabling the quickcheck feature requires Rust 1.12.0
-- Enabling the serde feature requires Rust 1.13.0
+The minimum supported Rust version for 1.0.\* releases is 1.36.0.
+Later 1.y.0 releases might require newer Rust versions, but the three most
+recent stable releases at the time of publishing will always be supported.  
+For example this means that if the current stable Rust version is 1.44 when
+ascii 1.1.0 is released, then ascii 1.1.* will not require a newer
+Rust version than 1.42.
 
 ## History
 

--- a/src/ascii_char.rs
+++ b/src/ascii_char.rs
@@ -367,7 +367,7 @@ impl AsciiChar {
     /// might not panic, creating a buffer overflow,
     /// and `Some(AsciiChar::from_ascii_unchecked(128))` might be `None`.
     #[inline]
-    pub unsafe fn from_ascii_unchecked<C: ToAsciiChar>(ch: C) -> Self {
+    pub unsafe fn from_ascii_unchecked(ch: u8) -> Self {
         ch.to_ascii_char_unchecked()
     }
 

--- a/src/ascii_char.rs
+++ b/src/ascii_char.rs
@@ -466,7 +466,7 @@ impl AsciiChar {
     pub fn as_printable_char(self) -> char {
         unsafe {
             match self as u8 {
-                b' '...b'~' => self.as_char(),
+                b' '..=b'~' => self.as_char(),
                 127 => '␡',
                 _ => char::from_u32_unchecked(self as u32 + '␀' as u32),
             }
@@ -488,7 +488,7 @@ impl AsciiChar {
     pub fn to_ascii_uppercase(&self) -> Self {
         unsafe {
             match *self as u8 {
-                b'a'...b'z' => AsciiChar::from_unchecked(self.as_byte() - (b'a' - b'A')),
+                b'a'..=b'z' => AsciiChar::from_unchecked(self.as_byte() - (b'a' - b'A')),
                 _ => *self,
             }
         }
@@ -499,7 +499,7 @@ impl AsciiChar {
     pub fn to_ascii_lowercase(&self) -> Self {
         unsafe {
             match *self as u8 {
-                b'A'...b'Z' => AsciiChar::from_unchecked(self.as_byte() + (b'a' - b'A')),
+                b'A'..=b'Z' => AsciiChar::from_unchecked(self.as_byte() + (b'a' - b'A')),
                 _ => *self,
             }
         }
@@ -571,7 +571,7 @@ impl_into_partial_eq_ord!{char, AsciiChar::as_char}
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct ToAsciiCharError(());
 
-const ERRORMSG_CHAR: &'static str = "not an ASCII character";
+const ERRORMSG_CHAR: &str = "not an ASCII character";
 
 #[cfg(not(feature = "std"))]
 impl ToAsciiCharError {
@@ -624,7 +624,7 @@ impl ToAsciiChar for AsciiChar {
 impl ToAsciiChar for u8 {
     #[inline]
     fn to_ascii_char(self) -> Result<AsciiChar, ToAsciiCharError> {
-        (self as u32).to_ascii_char()
+        u32::from(self).to_ascii_char()
     }
     #[inline]
     unsafe fn to_ascii_char_unchecked(self) -> AsciiChar {
@@ -671,7 +671,7 @@ impl ToAsciiChar for u32 {
 
 impl ToAsciiChar for u16 {
     fn to_ascii_char(self) -> Result<AsciiChar, ToAsciiCharError> {
-        (self as u32).to_ascii_char()
+        u32::from(self).to_ascii_char()
     }
     #[inline]
     unsafe fn to_ascii_char_unchecked(self) -> AsciiChar {

--- a/src/ascii_char.rs
+++ b/src/ascii_char.rs
@@ -1,16 +1,10 @@
 #![cfg_attr(rustfmt, rustfmt_skip)]
 
-// #[allow(deprecated)] doesn't silence warnings on the method invocations,
-// which would call the inherent methods if AsciiExt wasn't in scope.
-#![cfg_attr(feature = "std", allow(deprecated))]
-
 use core::mem;
 use core::cmp::Ordering;
 use core::{fmt, char};
 #[cfg(feature = "std")]
 use std::error::Error;
-#[cfg(feature = "std")]
-use std::ascii::AsciiExt;
 
 #[allow(non_camel_case_types)]
 /// An ASCII character. It wraps a `u8`, with the highest bit always zero.
@@ -531,48 +525,6 @@ impl fmt::Debug for AsciiChar {
     }
 }
 
-#[cfg(feature = "std")]
-impl AsciiExt for AsciiChar {
-    type Owned = AsciiChar;
-
-    #[inline]
-    fn is_ascii(&self) -> bool {
-        true
-    }
-
-    #[inline]
-    fn to_ascii_uppercase(&self) -> AsciiChar {
-        unsafe {
-            self.as_byte()
-                .to_ascii_uppercase()
-                .to_ascii_char_unchecked()
-        }
-    }
-
-    #[inline]
-    fn to_ascii_lowercase(&self) -> AsciiChar {
-        unsafe {
-            self.as_byte()
-                .to_ascii_lowercase()
-                .to_ascii_char_unchecked()
-        }
-    }
-
-    fn eq_ignore_ascii_case(&self, other: &Self) -> bool {
-        self.as_byte().eq_ignore_ascii_case(&other.as_byte())
-    }
-
-    #[inline]
-    fn make_ascii_uppercase(&mut self) {
-        *self = self.to_ascii_uppercase();
-    }
-
-    #[inline]
-    fn make_ascii_lowercase(&mut self) {
-        *self = self.to_ascii_lowercase();
-    }
-}
-
 impl Default for AsciiChar {
     fn default() -> AsciiChar {
         AsciiChar::Null
@@ -781,33 +733,17 @@ mod tests {
         assert_eq!(a.to_ascii_lowercase(), a);
         assert_eq!(a.to_ascii_uppercase(), A);
 
+        let mut mutable = (A,a);
+        mutable.0.make_ascii_lowercase();
+        mutable.1.make_ascii_uppercase();
+        assert_eq!(mutable.0, a);
+        assert_eq!(mutable.1, A);
+
         assert!(LineFeed.eq_ignore_ascii_case(&LineFeed));
         assert!(!LineFeed.eq_ignore_ascii_case(&CarriageReturn));
         assert!(z.eq_ignore_ascii_case(&Z));
         assert!(Z.eq_ignore_ascii_case(&z));
         assert!(!Z.eq_ignore_ascii_case(&DEL));
-    }
-
-    #[test]
-    #[cfg(feature = "std")]
-    fn ascii_ext() {
-        #[allow(deprecated)]
-        use std::ascii::AsciiExt;
-        assert!(AsciiExt::is_ascii(&Null));
-        assert!(AsciiExt::is_ascii(&DEL));
-        assert!(AsciiExt::eq_ignore_ascii_case(&a, &A));
-        assert!(!AsciiExt::eq_ignore_ascii_case(&A, &At));
-        assert_eq!(AsciiExt::to_ascii_lowercase(&A), a);
-        assert_eq!(AsciiExt::to_ascii_uppercase(&A), A);
-        assert_eq!(AsciiExt::to_ascii_lowercase(&a), a);
-        assert_eq!(AsciiExt::to_ascii_uppercase(&a), A);
-        assert_eq!(AsciiExt::to_ascii_lowercase(&At), At);
-        assert_eq!(AsciiExt::to_ascii_uppercase(&At), At);
-        let mut mutable = (A,a);
-        AsciiExt::make_ascii_lowercase(&mut mutable.0);
-        AsciiExt::make_ascii_uppercase(&mut mutable.1);
-        assert_eq!(mutable.0, a);
-        assert_eq!(mutable.1, A);
     }
 
     #[test]

--- a/src/ascii_char.rs
+++ b/src/ascii_char.rs
@@ -619,7 +619,7 @@ impl_into_partial_eq_ord!{char, AsciiChar::as_char}
 
 
 /// Error returned by `ToAsciiChar`.
-#[derive(PartialEq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub struct ToAsciiCharError(());
 
 const ERRORMSG_CHAR: &'static str = "not an ASCII character";

--- a/src/ascii_char.rs
+++ b/src/ascii_char.rs
@@ -404,7 +404,8 @@ impl AsciiChar {
     /// Check if the character is a letter (a-z, A-Z).
     ///
     /// This method is identical to [`is_alphabetic()`](#method.is_alphabetic)
-    pub fn is_ascii_alphabetic(&self) -> bool {
+    #[inline]
+    pub const fn is_ascii_alphabetic(&self) -> bool {
         self.is_alphabetic()
     }
 
@@ -452,7 +453,8 @@ impl AsciiChar {
     /// Check if the character is a letter or number
     ///
     /// This method is identical to [`is_alphanumeric()`](#method.is_alphanumeric)
-    pub fn is_ascii_alphanumeric(&self) -> bool {
+    #[inline]
+    pub const fn is_ascii_alphanumeric(&self) -> bool {
         self.is_alphanumeric()
     }
 
@@ -469,8 +471,8 @@ impl AsciiChar {
     /// assert!(!AsciiChar::FF.is_ascii_blank());
     /// ```
     #[inline]
-    pub const fn is_ascii_blank(self) -> bool {
-        (self as u8 == b' ') | (self as u8 == b'\t')
+    pub const fn is_ascii_blank(&self) -> bool {
+        (*self as u8 == b' ') | (*self as u8 == b'\t')
     }
 
     /// Check if the character one of ' ', '\t', '\n', '\r',
@@ -485,8 +487,10 @@ impl AsciiChar {
     ///
     /// This method is NOT identical to `is_whitespace()`.
     #[inline]
-    pub const fn is_ascii_whitespace(self) -> bool {
-        self.is_ascii_blank() | (self as u8 == b'\n') | (self as u8 == b'\r') | (self as u8 == 0x0c)
+    pub const fn is_ascii_whitespace(&self) -> bool {
+        self.is_ascii_blank()
+            | (*self as u8 == b'\n') | (*self as u8 == b'\r')
+            | (*self as u8 == 0x0c/*form feed*/)
     }
 
     /// Check if the character is a control character
@@ -551,7 +555,8 @@ impl AsciiChar {
     /// Checks if the character is alphabetic and lowercase (a-z).
     ///
     /// This method is identical to [`is_lowercase()`](#method.is_lowercase)
-    pub fn is_ascii_lowercase(&self) -> bool {
+    #[inline]
+    pub const fn is_ascii_lowercase(&self) -> bool {
         self.is_lowercase()
     }
 
@@ -572,7 +577,8 @@ impl AsciiChar {
     /// Checks if the character is alphabetic and uppercase (A-Z).
     ///
     /// This method is identical to [`is_uppercase()`](#method.is_uppercase)
-    pub fn is_ascii_uppercase(&self) -> bool {
+    #[inline]
+    pub const fn is_ascii_uppercase(&self) -> bool {
         self.is_uppercase()
     }
 

--- a/src/ascii_char.rs
+++ b/src/ascii_char.rs
@@ -732,7 +732,7 @@ impl Arbitrary for AsciiChar {
             }
             40...99 => {
                 // Completely arbitrary characters
-                unsafe { AsciiChar::from_unchecked(g.gen_range(0, 0x7F) as u8) }
+                unsafe { AsciiChar::from_unchecked(g.gen_range(0, 0x80) as u8) }
             }
             _ => unreachable!(),
         }

--- a/src/ascii_char.rs
+++ b/src/ascii_char.rs
@@ -675,12 +675,18 @@ impl ToAsciiChar for AsciiChar {
 impl ToAsciiChar for u8 {
     #[inline]
     fn to_ascii_char(self) -> Result<AsciiChar, ToAsciiCharError> {
-        unsafe {
-            if self <= 0x7F {
-                return Ok(self.to_ascii_char_unchecked());
-            }
-        }
-        Err(ToAsciiCharError(()))
+        (self as u32).to_ascii_char()
+    }
+    #[inline]
+    unsafe fn to_ascii_char_unchecked(self) -> AsciiChar {
+        mem::transmute(self)
+    }
+}
+
+impl ToAsciiChar for i8 {
+    #[inline]
+    fn to_ascii_char(self) -> Result<AsciiChar, ToAsciiCharError> {
+        (self as u32).to_ascii_char()
     }
     #[inline]
     unsafe fn to_ascii_char_unchecked(self) -> AsciiChar {
@@ -691,12 +697,32 @@ impl ToAsciiChar for u8 {
 impl ToAsciiChar for char {
     #[inline]
     fn to_ascii_char(self) -> Result<AsciiChar, ToAsciiCharError> {
+        (self as u32).to_ascii_char()
+    }
+    #[inline]
+    unsafe fn to_ascii_char_unchecked(self) -> AsciiChar {
+        (self as u32).to_ascii_char_unchecked()
+    }
+}
+
+impl ToAsciiChar for u32 {
+    fn to_ascii_char(self) -> Result<AsciiChar, ToAsciiCharError> {
         unsafe {
-            if self as u32 <= 0x7F {
-                return Ok(self.to_ascii_char_unchecked());
+            match self {
+                0..=127 => Ok(self.to_ascii_char_unchecked()),
+                _ => Err(ToAsciiCharError(()))
             }
         }
-        Err(ToAsciiCharError(()))
+    }
+    #[inline]
+    unsafe fn to_ascii_char_unchecked(self) -> AsciiChar {
+        (self as u8).to_ascii_char_unchecked()
+    }
+}
+
+impl ToAsciiChar for u16 {
+    fn to_ascii_char(self) -> Result<AsciiChar, ToAsciiCharError> {
+        (self as u32).to_ascii_char()
     }
     #[inline]
     unsafe fn to_ascii_char_unchecked(self) -> AsciiChar {
@@ -758,7 +784,7 @@ mod tests {
         assert_eq!(generic(A), Ok(A));
         assert_eq!(generic(b'A'), Ok(A));
         assert_eq!(generic('A'), Ok(A));
-        assert!(generic(200).is_err());
+        assert!(generic(200u16).is_err());
         assert!(generic('λ').is_err());
     }
 

--- a/src/ascii_char.rs
+++ b/src/ascii_char.rs
@@ -4,9 +4,6 @@
 // which would call the inherent methods if AsciiExt wasn't in scope.
 #![cfg_attr(feature = "std", allow(deprecated))]
 
-#[cfg(feature = "quickcheck")]
-use quickcheck::{Arbitrary, Gen};
-
 use core::mem;
 use core::cmp::Ordering;
 use core::{fmt, char};
@@ -727,47 +724,6 @@ impl ToAsciiChar for u16 {
     #[inline]
     unsafe fn to_ascii_char_unchecked(self) -> AsciiChar {
         (self as u8).to_ascii_char_unchecked()
-    }
-}
-
-#[cfg(feature = "quickcheck")]
-impl Arbitrary for AsciiChar {
-    fn arbitrary<G: Gen>(g: &mut G) -> Self {
-        let mode = g.gen_range(0, 100);
-        match mode {
-            0...14 => {
-                // Control characters
-                unsafe { AsciiChar::from_unchecked(g.gen_range(0, 0x1F) as u8) }
-            }
-            15...39 => {
-                // Characters often used in programming languages
-                *g.choose(&[
-                    AsciiChar::Space, AsciiChar::Tab, AsciiChar::LineFeed, AsciiChar::Tilde,
-                    AsciiChar::Grave, AsciiChar::Exclamation, AsciiChar::At, AsciiChar::Hash,
-                    AsciiChar::Dollar, AsciiChar::Percent, AsciiChar::Ampersand,
-                    AsciiChar::Asterisk, AsciiChar::ParenOpen, AsciiChar::ParenClose,
-                    AsciiChar::UnderScore, AsciiChar::Minus, AsciiChar::Equal, AsciiChar::Plus,
-                    AsciiChar::BracketOpen, AsciiChar::BracketClose, AsciiChar::CurlyBraceOpen,
-                    AsciiChar::CurlyBraceClose, AsciiChar::Colon, AsciiChar::Semicolon,
-                    AsciiChar::Apostrophe, AsciiChar::Quotation, AsciiChar::BackSlash,
-                    AsciiChar::VerticalBar, AsciiChar::Caret, AsciiChar::Comma, AsciiChar::LessThan,
-                    AsciiChar::GreaterThan, AsciiChar::Dot, AsciiChar::Slash, AsciiChar::Question,
-                    AsciiChar::_0, AsciiChar::_1, AsciiChar::_2, AsciiChar::_3, AsciiChar::_3,
-                    AsciiChar::_4 , AsciiChar::_6, AsciiChar::_7, AsciiChar::_8, AsciiChar::_9,
-                ]).unwrap()
-            }
-            40...99 => {
-                // Completely arbitrary characters
-                unsafe { AsciiChar::from_unchecked(g.gen_range(0, 0x80) as u8) }
-            }
-            _ => unreachable!(),
-        }
-    }
-
-    fn shrink(&self) -> Box<Iterator<Item = Self>> {
-        Box::new((*self as u8).shrink().filter_map(
-            |x| AsciiChar::from(x).ok(),
-        ))
     }
 }
 

--- a/src/ascii_char.rs
+++ b/src/ascii_char.rs
@@ -288,11 +288,11 @@ impl AsciiChar {
     /// # Example
     /// ```
     /// # use ascii::AsciiChar;
-    /// let a = AsciiChar::from('g').unwrap();
+    /// let a = AsciiChar::from_ascii('g').unwrap();
     /// assert_eq!(a.as_char(), 'g');
     /// ```
     #[inline]
-    pub fn from<C: ToAsciiChar>(ch: C) -> Result<Self, ToAsciiCharError> {
+    pub fn from_ascii<C: ToAsciiChar>(ch: C) -> Result<Self, ToAsciiCharError> {
         ch.to_ascii_char()
     }
 
@@ -301,7 +301,7 @@ impl AsciiChar {
     /// This function is intended for creating `AsciiChar` values from
     /// hardcoded known-good character literals such as `'K'`, `'-'` or `'\0'`,
     /// and for use in `const` contexts.
-    /// Use [`from_ascii()`](#tymethod.from_ascii) instead when you're not
+    /// Use [`from_ascii()`](#method.from_ascii) instead when you're not
     /// certain the character is ASCII.
     ///
     /// # Examples
@@ -353,9 +353,21 @@ impl AsciiChar {
         ALL[ch as usize]
     }
 
-    /// Constructs an ASCII character from a `char` or `u8` without any checks.
+    /// Constructs an ASCII character from a `u8`, `char` or other character
+    /// type without any checks.
+    ///
+    /// # Safety
+    ///
+    /// This function is very unsafe as it can create invalid enum
+    /// discriminants, which instantly creates undefined behavior.
+    /// (`let _ = AsciiChar::from_ascii_unchecked(200);` alone is UB).
+    ///
+    /// The undefined behavior is not just theoretical either:
+    /// For example, `[0; 128][AsciiChar::from_ascii_unchecked(255) as u8 as usize] = 0`
+    /// might not panic, creating a buffer overflow,
+    /// and `Some(AsciiChar::from_ascii_unchecked(128))` might be `None`.
     #[inline]
-    pub unsafe fn from_unchecked<C: ToAsciiChar>(ch: C) -> Self {
+    pub unsafe fn from_ascii_unchecked<C: ToAsciiChar>(ch: C) -> Self {
         ch.to_ascii_char_unchecked()
     }
 

--- a/src/ascii_str.rs
+++ b/src/ascii_str.rs
@@ -25,11 +25,6 @@ pub struct AsciiStr {
 }
 
 impl AsciiStr {
-    /// Coerces into an `AsciiStr` slice.
-    pub fn new<S: AsRef<AsciiStr> + ?Sized>(s: &S) -> &AsciiStr {
-        s.as_ref()
-    }
-
     /// Converts `&self` to a `&str` slice.
     #[inline]
     pub fn as_str(&self) -> &str {
@@ -85,7 +80,7 @@ impl AsciiStr {
     /// # Examples
     /// ```
     /// # use ascii::AsciiStr;
-    /// let foo = AsciiStr::from_ascii("foo");
+    /// let foo = AsciiStr::from_ascii(b"foo");
     /// let err = AsciiStr::from_ascii("Ŋ");
     /// assert_eq!(foo.unwrap().as_str(), "foo");
     /// assert_eq!(err.unwrap_err().valid_up_to(), 0);
@@ -104,15 +99,12 @@ impl AsciiStr {
     /// # Examples
     /// ```
     /// # use ascii::AsciiStr;
-    /// let foo = unsafe{ AsciiStr::from_ascii_unchecked("foo") };
+    /// let foo = unsafe { AsciiStr::from_ascii_unchecked(&b"foo"[..]) };
     /// assert_eq!(foo.as_str(), "foo");
     /// ```
     #[inline]
-    pub unsafe fn from_ascii_unchecked<B: ?Sized>(bytes: &B) -> &AsciiStr
-    where
-        B: AsRef<[u8]>,
-    {
-        bytes.as_ref().as_ascii_str_unchecked()
+    pub unsafe fn from_ascii_unchecked(bytes: &[u8]) -> &AsciiStr {
+        bytes.as_ascii_str_unchecked()
     }
 
     /// Returns the number of characters / bytes in this ASCII sequence.
@@ -167,7 +159,7 @@ impl AsciiStr {
     ///     .collect::<Vec<_>>();
     /// assert_eq!(words, ["apple", "banana", "lemon"]);
     /// ```
-    pub fn split(&self,  on: AsciiChar) -> Split {
+    pub fn split(&self, on: AsciiChar) -> impl DoubleEndedIterator<Item=&AsciiStr> {
         Split {
             on,
             ended: false,
@@ -181,7 +173,7 @@ impl AsciiStr {
     ///
     /// The final line ending is optional.
     #[inline]
-    pub fn lines(&self) -> Lines {
+    pub fn lines(&self) -> impl DoubleEndedIterator<Item=&AsciiStr> {
         Lines {
             string: self,
         }
@@ -587,7 +579,7 @@ impl<'a> DoubleEndedIterator for CharsRef<'a> {
 ///
 /// This type is created by [`AsciiChar::split()`](struct.AsciiChar.html#method.split).
 #[derive(Clone, Debug)]
-pub struct Split<'a> {
+struct Split<'a> {
     on: AsciiChar,
     ended: bool,
     chars: Chars<'a>
@@ -629,7 +621,7 @@ impl<'a> DoubleEndedIterator for Split<'a> {
 
 /// An iterator over the lines of the internal character array.
 #[derive(Clone, Debug)]
-pub struct Lines<'a> {
+struct Lines<'a> {
     string: &'a AsciiStr,
 }
 impl<'a> Iterator for Lines<'a> {

--- a/src/ascii_str.rs
+++ b/src/ascii_str.rs
@@ -1,7 +1,8 @@
 #![cfg_attr(rustfmt, rustfmt_skip)]
 
 use core::fmt;
-use core::ops::{Index, IndexMut, Range, RangeTo, RangeFrom, RangeFull};
+use core::ops::{Index, IndexMut};
+use core::ops::{Range, RangeTo, RangeFrom, RangeFull, RangeInclusive, RangeToInclusive};
 use core::slice::{Iter, IterMut};
 #[cfg(feature = "std")]
 use std::error::Error;
@@ -453,6 +454,8 @@ impl_index! { Range<usize> }
 impl_index! { RangeTo<usize> }
 impl_index! { RangeFrom<usize> }
 impl_index! { RangeFull }
+impl_index! { RangeInclusive<usize> }
+impl_index! { RangeToInclusive<usize> }
 
 impl Index<usize> for AsciiStr {
     type Output = AsciiChar;
@@ -941,6 +944,26 @@ mod tests {
     fn default() {
         let default: &'static AsciiStr = Default::default();
         assert!(default.is_empty());
+    }
+
+    #[test]
+    fn index() {
+        let mut arr = [AsciiChar::A, AsciiChar::B, AsciiChar::C, AsciiChar::D];
+        let a: &AsciiStr = arr[..].into();
+        assert_eq!(a[..].as_slice(), &a.as_slice()[..]);
+        assert_eq!(a[..4].as_slice(), &a.as_slice()[..4]);
+        assert_eq!(a[4..].as_slice(), &a.as_slice()[4..]);
+        assert_eq!(a[2..3].as_slice(), &a.as_slice()[2..3]);
+        assert_eq!(a[..=3].as_slice(), &a.as_slice()[..=3]);
+        assert_eq!(a[1..=1].as_slice(), &a.as_slice()[1..=1]);
+        let mut copy = arr.clone();
+        let a_mut: &mut AsciiStr = {&mut arr[..]}.into();
+        assert_eq!(a_mut[..].as_mut_slice(), &mut copy[..]);
+        assert_eq!(a_mut[..2].as_mut_slice(), &mut copy[..2]);
+        assert_eq!(a_mut[3..].as_mut_slice(), &mut copy[3..]);
+        assert_eq!(a_mut[4..4].as_mut_slice(), &mut copy[4..4]);
+        assert_eq!(a_mut[..=0].as_mut_slice(), &mut copy[..=0]);
+        assert_eq!(a_mut[0..=2].as_mut_slice(), &mut copy[0..=2]);
     }
 
     #[test]

--- a/src/ascii_str.rs
+++ b/src/ascii_str.rs
@@ -1088,7 +1088,7 @@ mod tests {
         fn split_equals_str(haystack: &str, needle: char) {
             let mut strs = haystack.split(needle);
             let mut asciis = haystack.as_ascii_str().unwrap()
-                .split(AsciiChar::from(needle).unwrap())
+                .split(AsciiChar::from_ascii(needle).unwrap())
                 .map(|a| a.as_str());
             loop {
                 assert_eq!(asciis.size_hint(), strs.size_hint());

--- a/src/ascii_str.rs
+++ b/src/ascii_str.rs
@@ -1152,14 +1152,16 @@ mod tests {
     #[test]
     fn index() {
         let mut arr = [AsciiChar::A, AsciiChar::B, AsciiChar::C, AsciiChar::D];
-        let a: &AsciiStr = arr[..].into();
-        assert_eq!(a[..].as_slice(), &a.as_slice()[..]);
-        assert_eq!(a[..4].as_slice(), &a.as_slice()[..4]);
-        assert_eq!(a[4..].as_slice(), &a.as_slice()[4..]);
-        assert_eq!(a[2..3].as_slice(), &a.as_slice()[2..3]);
-        assert_eq!(a[..=3].as_slice(), &a.as_slice()[..=3]);
-        assert_eq!(a[1..=1].as_slice(), &a.as_slice()[1..=1]);
-        let mut copy = arr.clone();
+        {
+            let a: &AsciiStr = arr[..].into();
+            assert_eq!(a[..].as_slice(), &a.as_slice()[..]);
+            assert_eq!(a[..4].as_slice(), &a.as_slice()[..4]);
+            assert_eq!(a[4..].as_slice(), &a.as_slice()[4..]);
+            assert_eq!(a[2..3].as_slice(), &a.as_slice()[2..3]);
+            assert_eq!(a[..=3].as_slice(), &a.as_slice()[..=3]);
+            assert_eq!(a[1..=1].as_slice(), &a.as_slice()[1..=1]);
+        }
+        let mut copy = arr;
         let a_mut: &mut AsciiStr = {&mut arr[..]}.into();
         assert_eq!(a_mut[..].as_mut_slice(), &mut copy[..]);
         assert_eq!(a_mut[..2].as_mut_slice(), &mut copy[..2]);

--- a/src/ascii_str.rs
+++ b/src/ascii_str.rs
@@ -3,7 +3,7 @@
 use core::fmt;
 use core::ops::{Index, IndexMut};
 use core::ops::{Range, RangeTo, RangeFrom, RangeFull, RangeInclusive, RangeToInclusive};
-use core::slice::{Iter, IterMut};
+use core::slice::{self, Iter, IterMut};
 #[cfg(feature = "std")]
 use std::error::Error;
 #[cfg(feature = "std")]
@@ -355,6 +355,18 @@ impl From<Box<[AsciiChar]>> for Box<AsciiStr> {
     }
 }
 
+impl AsRef<AsciiStr> for AsciiStr {
+    #[inline]
+    fn as_ref(&self) -> &AsciiStr {
+        self
+    }
+}
+impl AsMut<AsciiStr> for AsciiStr {
+    #[inline]
+    fn as_mut(&mut self) -> &mut AsciiStr {
+        self
+    }
+}
 impl AsRef<AsciiStr> for [AsciiChar] {
     #[inline]
     fn as_ref(&self) -> &AsciiStr {
@@ -407,6 +419,13 @@ macro_rules! widen_box {
 widen_box! {[AsciiChar]}
 widen_box! {[u8]}
 widen_box! {str}
+
+// allows &AsciiChar to be used by generic AsciiString Extend and FromIterator
+impl AsRef<AsciiStr> for AsciiChar {
+    fn as_ref(&self) -> &AsciiStr {
+        slice::from_ref(self).into()
+    }
+}
 
 impl fmt::Display for AsciiStr {
     #[inline]

--- a/src/ascii_str.rs
+++ b/src/ascii_str.rs
@@ -20,6 +20,7 @@ use ascii_string::AsciiString;
 /// It can be created by a checked conversion from a `str` or `[u8]`, or borrowed from an
 /// `AsciiString`.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
 pub struct AsciiStr {
     slice: [AsciiChar],
 }

--- a/src/ascii_str.rs
+++ b/src/ascii_str.rs
@@ -1,16 +1,10 @@
 #![cfg_attr(rustfmt, rustfmt_skip)]
 
-// #[allow(deprecated)] doesn't silence warnings on the method invocations,
-// which would call the inherent methods if AsciiExt wasn't in scope.
-#![cfg_attr(feature = "std", allow(deprecated))]
-
 use core::fmt;
 use core::ops::{Index, IndexMut, Range, RangeTo, RangeFrom, RangeFull};
 use core::slice::{Iter, IterMut};
 #[cfg(feature = "std")]
 use std::error::Error;
-#[cfg(feature = "std")]
-use std::ascii::AsciiExt;
 #[cfg(feature = "std")]
 use std::ffi::CStr;
 
@@ -476,47 +470,6 @@ impl IndexMut<usize> for AsciiStr {
     }
 }
 
-#[cfg(feature = "std")]
-impl AsciiExt for AsciiStr {
-    type Owned = AsciiString;
-
-    #[inline]
-    fn is_ascii(&self) -> bool {
-        true
-    }
-
-    fn to_ascii_uppercase(&self) -> AsciiString {
-        let mut ascii_string = self.to_ascii_string();
-        ascii_string.make_ascii_uppercase();
-        ascii_string
-    }
-
-    fn to_ascii_lowercase(&self) -> AsciiString {
-        let mut ascii_string = self.to_ascii_string();
-        ascii_string.make_ascii_lowercase();
-        ascii_string
-    }
-
-    fn eq_ignore_ascii_case(&self, other: &Self) -> bool {
-        self.len() == other.len() &&
-            self.chars().zip(other.chars()).all(|(a, b)| {
-                a.eq_ignore_ascii_case(b)
-            })
-    }
-
-    fn make_ascii_uppercase(&mut self) {
-        for ascii in self.chars_mut() {
-            ascii.make_ascii_uppercase();
-        }
-    }
-
-    fn make_ascii_lowercase(&mut self) {
-        for ascii in self.chars_mut() {
-            ascii.make_ascii_lowercase();
-        }
-    }
-}
-
 impl<'a> IntoIterator for &'a AsciiStr {
     type Item = &'a AsciiChar;
     type IntoIter = Chars<'a>;
@@ -943,25 +896,6 @@ mod tests {
         assert_eq!(a.to_ascii_uppercase().as_str(), "A@A");
         assert_eq!(b.to_ascii_lowercase().as_str(), "a@a");
         assert_eq!(b.to_ascii_uppercase().as_str(), "A@A");
-    }
-
-    #[test]
-    #[cfg(feature = "std")]
-    fn ascii_ext() {
-        #[allow(deprecated)]
-        use std::ascii::AsciiExt;
-        assert!(AsciiExt::is_ascii(<&AsciiStr>::default()));
-        let mut mutable = String::from("a@AA@a");
-        let parts = mutable.split_at_mut(3);
-        let a = parts.0.as_mut_ascii_str().unwrap();
-        let b = parts.1.as_mut_ascii_str().unwrap();
-        assert!(AsciiExt::eq_ignore_ascii_case(a, b));
-        assert_eq!(AsciiExt::to_ascii_lowercase(a).as_str(), "a@a");
-        assert_eq!(AsciiExt::to_ascii_uppercase(b).as_str(), "A@A");
-        AsciiExt::make_ascii_uppercase(a);
-        AsciiExt::make_ascii_lowercase(b);
-        assert_eq!(a, "A@A");
-        assert_eq!(b, "a@a");
     }
 
     #[test]

--- a/src/ascii_str.rs
+++ b/src/ascii_str.rs
@@ -195,7 +195,7 @@ impl AsciiStr {
     /// assert_eq!("white \tspace", example.trim());
     /// ```
     pub fn trim(&self) -> &Self {
-        self.trim_right().trim_left()
+        self.trim_start().trim_end()
     }
 
     /// Returns an ASCII string slice with leading whitespace removed.
@@ -204,9 +204,9 @@ impl AsciiStr {
     /// ```
     /// # use ascii::AsciiStr;
     /// let example = AsciiStr::from_ascii("  \twhite \tspace  \t").unwrap();
-    /// assert_eq!("white \tspace  \t", example.trim_left());
+    /// assert_eq!("white \tspace  \t", example.trim_start());
     /// ```
-    pub fn trim_left(&self) -> &Self {
+    pub fn trim_start(&self) -> &Self {
         &self[self.chars().take_while(|a| a.is_whitespace()).count()..]
     }
 
@@ -216,9 +216,9 @@ impl AsciiStr {
     /// ```
     /// # use ascii::AsciiStr;
     /// let example = AsciiStr::from_ascii("  \twhite \tspace  \t").unwrap();
-    /// assert_eq!("  \twhite \tspace", example.trim_right());
+    /// assert_eq!("  \twhite \tspace", example.trim_end());
     /// ```
-    pub fn trim_right(&self) -> &Self {
+    pub fn trim_end(&self) -> &Self {
         let trimmed = self.chars()
             .rev()
             .take_while(|a| a.is_whitespace())

--- a/src/ascii_str.rs
+++ b/src/ascii_str.rs
@@ -39,7 +39,7 @@ impl AsciiStr {
 
     /// Returns the entire string as slice of `AsciiChar`s.
     #[inline]
-    pub fn as_slice(&self) -> &[AsciiChar] {
+    pub const fn as_slice(&self) -> &[AsciiChar] {
         &self.slice
     }
 
@@ -55,7 +55,7 @@ impl AsciiStr {
     /// will end up pointing to garbage. Modifying the `AsciiStr` may cause it's buffer to be
     /// reallocated, which would also make any pointers to it invalid.
     #[inline]
-    pub fn as_ptr(&self) -> *const AsciiChar {
+    pub const fn as_ptr(&self) -> *const AsciiChar {
         self.as_slice().as_ptr()
     }
 
@@ -683,13 +683,13 @@ impl AsAsciiStrError {
     ///
     /// It is the maximum index such that `from_ascii(input[..index])` would return `Ok(_)`.
     #[inline]
-    pub fn valid_up_to(self) -> usize {
+    pub const fn valid_up_to(self) -> usize {
         self.0
     }
     #[cfg(not(feature = "std"))]
     /// Returns a description for this error, like `std::error::Error::description`.
     #[inline]
-    pub fn description(&self) -> &'static str {
+    pub const fn description(&self) -> &'static str {
         ERRORMSG_STR
     }
 }

--- a/src/ascii_str.rs
+++ b/src/ascii_str.rs
@@ -169,7 +169,7 @@ impl AsciiStr {
     /// ```
     pub fn split(&self,  on: AsciiChar) -> Split {
         Split {
-            on: on,
+            on,
             ended: false,
             chars: self.chars(),
         }
@@ -684,7 +684,7 @@ impl<'a> DoubleEndedIterator for Lines<'a> {
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct AsAsciiStrError(usize);
 
-const ERRORMSG_STR: &'static str = "one or more bytes are not ASCII";
+const ERRORMSG_STR: &str = "one or more bytes are not ASCII";
 
 impl AsAsciiStrError {
     /// Returns the index of the first non-ASCII byte.

--- a/src/ascii_string.rs
+++ b/src/ascii_string.rs
@@ -14,6 +14,7 @@ use ascii_str::{AsciiStr, AsAsciiStr, AsAsciiStrError};
 
 /// A growable string stored as an ASCII encoded buffer.
 #[derive(Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
 pub struct AsciiString {
     vec: Vec<AsciiChar>,
 }

--- a/src/ascii_string.rs
+++ b/src/ascii_string.rs
@@ -225,9 +225,9 @@ impl AsciiString {
     /// ```
     /// # use ascii::{ AsciiChar, AsciiString};
     /// let mut s = AsciiString::from_ascii("abc").unwrap();
-    /// s.push(AsciiChar::from('1').unwrap());
-    /// s.push(AsciiChar::from('2').unwrap());
-    /// s.push(AsciiChar::from('3').unwrap());
+    /// s.push(AsciiChar::from_ascii('1').unwrap());
+    /// s.push(AsciiChar::from_ascii('2').unwrap());
+    /// s.push(AsciiChar::from_ascii('3').unwrap());
     /// assert_eq!(s, "abc123");
     /// ```
     #[inline]
@@ -330,7 +330,7 @@ impl AsciiString {
     /// # use ascii::{AsciiChar, AsciiString};
     /// let mut s = AsciiString::new();
     /// assert!(s.is_empty());
-    /// s.push(AsciiChar::from('a').unwrap());
+    /// s.push(AsciiChar::from_ascii('a').unwrap());
     /// assert!(!s.is_empty());
     /// ```
     #[inline]
@@ -557,7 +557,7 @@ impl fmt::Write for AsciiString {
     }
 
     fn write_char(&mut self, c: char) -> fmt::Result {
-        if let Ok(achar) = AsciiChar::from(c) {
+        if let Ok(achar) = AsciiChar::from_ascii(c) {
             self.push(achar);
             Ok(())
         } else {
@@ -909,7 +909,7 @@ mod tests {
 
     #[test]
     fn from_ascii_vec() {
-        let vec = vec![AsciiChar::from('A').unwrap(), AsciiChar::from('B').unwrap()];
+        let vec = vec![AsciiChar::from_ascii('A').unwrap(), AsciiChar::from_ascii('B').unwrap()];
         assert_eq!(AsciiString::from(vec), AsciiString::from_str("AB").unwrap());
     }
 

--- a/src/ascii_string.rs
+++ b/src/ascii_string.rs
@@ -566,65 +566,21 @@ impl fmt::Write for AsciiString {
     }
 }
 
-impl FromIterator<AsciiChar> for AsciiString {
-    fn from_iter<I: IntoIterator<Item = AsciiChar>>(iter: I) -> AsciiString {
+impl<A: AsRef<AsciiStr>> FromIterator<A> for AsciiString {
+    fn from_iter<I: IntoIterator<Item = A>>(iter: I) -> AsciiString {
         let mut buf = AsciiString::new();
         buf.extend(iter);
         buf
     }
 }
 
-impl<'a> FromIterator<&'a AsciiStr> for AsciiString {
-    fn from_iter<I: IntoIterator<Item = &'a AsciiStr>>(iter: I) -> AsciiString {
-        let mut buf = AsciiString::new();
-        buf.extend(iter);
-        buf
-    }
-}
-
-impl<'a> FromIterator<Cow<'a, AsciiStr>> for AsciiString {
-    fn from_iter<I: IntoIterator<Item = Cow<'a, AsciiStr>>>(iter: I) -> AsciiString {
-        let mut buf = AsciiString::new();
-        buf.extend(iter);
-        buf
-    }
-}
-
-impl Extend<AsciiChar> for AsciiString {
-    fn extend<I: IntoIterator<Item = AsciiChar>>(&mut self, iterable: I) {
+impl<A: AsRef<AsciiStr>> Extend<A> for AsciiString {
+    fn extend<I: IntoIterator<Item = A>>(&mut self, iterable: I) {
         let iterator = iterable.into_iter();
         let (lower_bound, _) = iterator.size_hint();
         self.reserve(lower_bound);
-        for ch in iterator {
-            self.push(ch)
-        }
-    }
-}
-
-impl<'a> Extend<&'a AsciiChar> for AsciiString {
-    fn extend<I: IntoIterator<Item = &'a AsciiChar>>(&mut self, iter: I) {
-        self.extend(iter.into_iter().cloned())
-    }
-}
-
-impl<'a> Extend<&'a AsciiStr> for AsciiString {
-    fn extend<I: IntoIterator<Item = &'a AsciiStr>>(&mut self, iterable: I) {
-        let iterator = iterable.into_iter();
-        let (lower_bound, _) = iterator.size_hint();
-        self.reserve(lower_bound);
-        for s in iterator {
-            self.push_str(s)
-        }
-    }
-}
-
-impl<'a> Extend<Cow<'a, AsciiStr>> for AsciiString {
-    fn extend<I: IntoIterator<Item = Cow<'a,AsciiStr>>>(&mut self, iterable: I) {
-        let iterator = iterable.into_iter();
-        let (lower_bound, _) = iterator.size_hint();
-        self.reserve(lower_bound);
-        for s in iterator {
-            self.push_str(&*s);
+        for item in iterator {
+            self.push_str(item.as_ref())
         }
     }
 }

--- a/src/ascii_string.rs
+++ b/src/ascii_string.rs
@@ -451,7 +451,7 @@ impl<'a> From<&'a AsciiStr> for AsciiString {
 impl<'a> From<&'a [AsciiChar]> for AsciiString {
     #[inline]
     fn from(s: &'a [AsciiChar]) -> AsciiString {
-        s.iter().copied().collect()
+        s.iter().cloned().collect()
     }
 }
 

--- a/src/ascii_string.rs
+++ b/src/ascii_string.rs
@@ -9,9 +9,6 @@ use std::str::FromStr;
 use std::ops::{Deref, DerefMut, Add, AddAssign, Index, IndexMut};
 use std::iter::FromIterator;
 
-#[cfg(feature = "quickcheck")]
-use quickcheck::{Arbitrary, Gen};
-
 use ascii_char::AsciiChar;
 use ascii_str::{AsciiStr, AsAsciiStr, AsAsciiStrError};
 
@@ -886,28 +883,6 @@ where
                     })
             }
         }
-    }
-}
-
-#[cfg(feature = "quickcheck")]
-impl Arbitrary for AsciiString {
-    fn arbitrary<G: Gen>(g: &mut G) -> Self {
-        let size = {
-            let s = g.size();
-            g.gen_range(0, s)
-        };
-        let mut s = AsciiString::with_capacity(size);
-        for _ in 0..size {
-            s.push(AsciiChar::arbitrary(g));
-        }
-        s
-    }
-
-    fn shrink(&self) -> Box<Iterator<Item = Self>> {
-        let chars: Vec<AsciiChar> = self.as_slice().to_vec();
-        Box::new(chars.shrink().map(
-            |x| x.into_iter().collect::<AsciiString>(),
-        ))
     }
 }
 

--- a/src/free_functions.rs
+++ b/src/free_functions.rs
@@ -55,7 +55,7 @@ pub fn caret_decode<C: Copy + Into<u8>>(c: C) -> Option<AsciiChar> {
     // The formula is explained in the Wikipedia article.
     unsafe {
         match c.into() {
-            b'?'..=b'_' => Some(AsciiChar::from_unchecked(c.into() ^ 0b0100_0000)),
+            b'?'..=b'_' => Some(AsciiChar::from_ascii_unchecked(c.into() ^ 0b0100_0000)),
             _ => None,
         }
     }

--- a/src/free_functions.rs
+++ b/src/free_functions.rs
@@ -55,7 +55,7 @@ pub fn caret_decode<C: Copy + Into<u8>>(c: C) -> Option<AsciiChar> {
     // The formula is explained in the Wikipedia article.
     unsafe {
         match c.into() {
-            b'?'...b'_' => Some(AsciiChar::from_unchecked(c.into() ^ 0b0100_0000)),
+            b'?'..=b'_' => Some(AsciiChar::from_unchecked(c.into() ^ 0b0100_0000)),
             _ => None,
         }
     }

--- a/src/free_functions.rs
+++ b/src/free_functions.rs
@@ -2,8 +2,6 @@
 
 use ascii_char::{AsciiChar, ToAsciiChar};
 
-// I would like to require C: AsciiExt, but it's not in core.
-
 /// Terminals use [caret notation](https://en.wikipedia.org/wiki/Caret_notation)
 /// to display some typed control codes, such as ^D for EOT and ^Z for SUB.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,9 +32,6 @@
 #[cfg(feature = "std")]
 extern crate core;
 
-#[cfg(feature = "quickcheck")]
-extern crate quickcheck;
-
 #[cfg(feature = "serde")]
 extern crate serde;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,12 +17,12 @@
 //!
 //! # Minimum supported Rust version
 //!
-//! The minimum supported Rust version for 1.0.\* releases is 1.36.0.
+//! The minimum Rust version for 1.0.\* releases is 1.33.0.
 //! Later 1.y.0 releases might require newer Rust versions, but the three most
 //! recent stable releases at the time of publishing will always be supported.  
-//! For example this means that if the current stable Rust version is 1.44 when
+//! For example this means that if the current stable Rust version is 1.38 when
 //! ascii 1.1.0 is released, then ascii 1.1.* will not require a newer
-//! Rust version than 1.42.
+//! Rust version than 1.36.
 //!
 //! # History
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,8 @@ mod free_functions;
 mod serialization;
 
 pub use ascii_char::{AsciiChar, ToAsciiChar, ToAsciiCharError};
-pub use ascii_str::{AsciiStr, AsAsciiStr, AsMutAsciiStr, AsAsciiStrError, Chars, CharsMut, Lines};
+pub use ascii_str::{AsciiStr, AsAsciiStr, AsMutAsciiStr, AsAsciiStrError};
+pub use ascii_str::{Chars, CharsMut, CharsRef, Lines, Split};
 #[cfg(feature = "std")]
 pub use ascii_string::{AsciiString, IntoAsciiString, FromAsciiError};
 pub use free_functions::{caret_encode, caret_decode};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,8 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+#![allow(clippy::trivially_copy_pass_by_ref)] // for compatibility with methods on char and u8
+
 #[cfg(feature = "std")]
 extern crate core;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,6 @@
 //! A library that provides ASCII-only string and character types, equivalent to the `char`, `str`
 //! and `String` types in the standard library.
 //!
-#![cfg_attr(feature = "std", doc="[The documentation for the `core` mode is here](https://tomprogrammer.github.io/rust-ascii/core/ascii/index.html).")]
-#![cfg_attr(not(feature = "std"), doc="This is the documentation for `core` mode.")]
 //! Please refer to the readme file to learn about the different feature modes of this crate.
 //!
 //! # Requirements

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,11 +15,14 @@
 //!
 //! Please refer to the readme file to learn about the different feature modes of this crate.
 //!
-//! # Requirements
+//! # Minimum supported Rust version
 //!
-//! - The minimum supported Rust version is 1.9.0
-//! - Enabling the quickcheck feature requires Rust 1.12.0
-//! - Enabling the serde feature requires Rust 1.13.0
+//! The minimum supported Rust version for 1.0.\* releases is 1.36.0.
+//! Later 1.y.0 releases might require newer Rust versions, but the three most
+//! recent stable releases at the time of publishing will always be supported.  
+//! For example this means that if the current stable Rust version is 1.44 when
+//! ascii 1.1.0 is released, then ascii 1.1.* will not require a newer
+//! Rust version than 1.42.
 //!
 //! # History
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ mod serialization;
 
 pub use ascii_char::{AsciiChar, ToAsciiChar, ToAsciiCharError};
 pub use ascii_str::{AsciiStr, AsAsciiStr, AsMutAsciiStr, AsAsciiStrError};
-pub use ascii_str::{Chars, CharsMut, CharsRef, Lines, Split};
+pub use ascii_str::{Chars, CharsMut, CharsRef};
 #[cfg(feature = "std")]
 pub use ascii_string::{AsciiString, IntoAsciiString, FromAsciiError};
 pub use free_functions::{caret_encode, caret_decode};

--- a/src/serialization/ascii_char.rs
+++ b/src/serialization/ascii_char.rs
@@ -23,7 +23,7 @@ impl<'de> Visitor<'de> for AsciiCharVisitor {
 
     #[inline]
     fn visit_char<E: Error>(self, v: char) -> Result<Self::Value, E> {
-        AsciiChar::from(v).map_err(|_| Error::invalid_value(Unexpected::Char(v), &self))
+        AsciiChar::from_ascii(v).map_err(|_| Error::invalid_value(Unexpected::Char(v), &self))
     }
 
     #[inline]
@@ -69,7 +69,7 @@ mod tests {
     #[cfg(feature = "serde_test")]
     fn serialize() {
         use serde_test::{assert_tokens, Token};
-        let ascii_char = AsciiChar::from(ASCII_CHAR).unwrap();
+        let ascii_char = AsciiChar::from_ascii(ASCII_CHAR).unwrap();
         assert_tokens(&ascii_char, &[Token::Char(ASCII_CHAR)]);
     }
 
@@ -77,7 +77,7 @@ mod tests {
     #[cfg(feature = "serde_test")]
     fn deserialize() {
         use serde_test::{assert_de_tokens, assert_de_tokens_error, Token};
-        let ascii_char = AsciiChar::from(ASCII_CHAR).unwrap();
+        let ascii_char = AsciiChar::from_ascii(ASCII_CHAR).unwrap();
         assert_de_tokens(&ascii_char, &[Token::String(ASCII_STR)]);
         assert_de_tokens(&ascii_char, &[Token::Str(ASCII_STR)]);
         assert_de_tokens(&ascii_char, &[Token::BorrowedStr(ASCII_STR)]);

--- a/tests.rs
+++ b/tests.rs
@@ -137,5 +137,6 @@ fn extend_from_iterator() {
             }
         });
     s.extend(cows);
-    assert_eq!(s, "abcabconetwothreeASCIIASCIIASCII");
+    s.extend(&[AsciiChar::LineFeed]);
+    assert_eq!(s, "abcabconetwothreeASCIIASCIIASCII\n");
 }

--- a/tests.rs
+++ b/tests.rs
@@ -118,7 +118,7 @@ fn extend_from_iterator() {
     use ::std::borrow::Cow;
 
     let abc = "abc".as_ascii_str().unwrap();
-    let mut s = abc.chars().cloned().collect::<AsciiString>();
+    let mut s = abc.chars().collect::<AsciiString>();
     assert_eq!(s, abc);
     s.extend(abc);
     assert_eq!(s, "abcabc");


### PR DESCRIPTION
I said I'd finish up my changes this weekend, and here they are.
It naturally turned into much more work than expected, mostly because in the process i found unsound trait impls, many inconsistencies, a way to make a `const fn` for creating `AsciiChar` from `char`, and many other small things I felt like changing.

Changelog:
* Remove [unsound `impl From<&mut AsciiStr> for &mut [u8]` and for `&mut str`](https://github.com/tomprogrammer/rust-ascii/issues/64).
* Remove quickcheck.
* Rename `AsciiStr.trim_left()` and `AsciiStr.trim_right()` to `trim_start()` and `trim_end()`.
* Rename `AsciiChar::from{,_unchecked}()` to `from_ascii{,_unchecked}()`.
* Remove impls of deprecated `std::ascii::AsciiExt` trait.
* Rename some `AsciiChar` variants, most significantly `Null` to `Nul` (for consistency with `CStr` method names).
* Remove `AsciiStr::new()` (in preparation for making it `const` sooner or changing it).
* Make `from_ascii_unchecked()` non-generic (in preparation for making it `const` sooner).
* Change `Chars` iterator returned by `AsciiStr::chars()` to produce values instead of references.
* Change `AsciiChar::is_whitespace()` to return `true` for form-feed and vertical tab (for consistency with `char::is_whitespace()`.
* Change many `AsciiChar` methods to take self by reference for maximum compatibility with `u8` and `char`.
* Add `slice_ascii_str()` and `get_ascii()` to `AsAsciiStr` and `slice_mut_ascii_str()` to `AsMutAsciiStr`.
* Hide `Lines` and `Split` behind `impl Trait`.
* Change `Chars` and `CharsMut` from being typedefs for `[AsciiChar]` iterators to being newtypes.
* Require Rust 1.36 for 1.0.\*, and allow later semver-compatible releases to increase it.
* Make most `AsciiChar` methods `const fn` and add `AsciiChar::new()`.
* Implement `AsRef<AsciiStr>` for `AsciiChar` and `AsciiStr`, and `AsMut<AsciiStr>` for `AsciiStr`.
* Implement `ToAsciiChar` for `i8`, `u16` and `u32`.
* Implement `Clone`, `Copy` and `Eq` for `ToAsciiCharError`.
* Add many `is_xxx()` methods to `AsciiChar`.