### PR TITLE
Fix unsoundness for 0.9 too

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0 / MIT"
 name = "ascii"
 readme = "README.md"
 repository = "https://github.com/tomprogrammer/rust-ascii"
-version = "0.9.2"
+version = "0.9.3"
 
 [dependencies]
 quickcheck = { version = "0.6", optional = true }

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ ascii = "0.9"
 
 Most of `AsciiChar` and `AsciiStr` can be used without `std` by disabling the
 default features. The owned string type `AsciiString` and the conversion trait
-`IntoAsciiString` as well as all methods referring to these types are
-unavailable. The `Error` trait is also unavailable, but `description()` is made
+`IntoAsciiString` as well as all methods referring to these types and
+`CStr` and `CString` are unavailable.
+The `Error` trait is also unavailable, but `description()` is made
 available as an inherent method for `ToAsciiCharError` and `AsAsciiStrError`.
 
 To use the `ascii` crate in `core`-only mode in your cargo project just add the

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,20 @@
+Version 0.9.3 (2019-08-25)
+==========================
+
+Soundness fix:
+
+**Remove** [unsound](https://github.com/tomprogrammer/rust-ascii/issues/64) impls of `From<&mut AsciiStr>` for `&mut [u8]` and `&mut str`.
+This is a breaking change, but theese impls can lead to undefined behavior in safe code.
+
+If you use this impl and know that non-ASCII values are never inserted into the `[u8]` or `str`,
+you can pin ascii to 0.9.2.
+
+Other changes:
+
+* Make quickcheck `Arbitrary` impl sometimes produce `AsciiChar::DEL`.
+* Implement `Clone`, `Copy` and `Eq` for `ToAsciiCharError`.
+* Implement `ToAsciiChar` for `u16`, `u32` and `i8`.
+
 Version 0.9.2 (2019-07-07)
 ==========================
 * Implement the `IntoAsciiString` trait for `std::ffi::CStr` and `std::ffi::CString` types,


### PR DESCRIPTION
Doing nothing about #64 for 0.9 feels wrong, so here is two commits to release efb6e59c...dc7e07397 as 0.9.3.

Release date in RELEASES.md is set to this Sunday so that you don't need to edit it if you release within a few days.

I've tested all reverse dependencies of 0.9 on crates.io (except ncursesw which requires windows) and 0.8, and none breaks.

This PR should not be merged to master. (Github doesn't have a way to create PR for a new branch)