### PR TITLE
Mark AsciiString::new() as 'const fn'

### DIFF
--- a/src/ascii_string.rs
+++ b/src/ascii_string.rs
@@ -28,7 +28,7 @@ impl AsciiString {
     /// let mut s = AsciiString::new();
     /// ```
     #[inline]
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         AsciiString { vec: Vec::new() }
     }
 


### PR DESCRIPTION
Since 'Vec::new()' is already a const function,
there is no difference in generated MIR/ASM whether
`AsciiString::new()` is marked `const` or not.
I saw issue #56 is waiting to mark this function as 'const',
and this PR simply marks 'AsciiString::new()' as a const fn.

`cargo test` successfully passed all tests in my local environment.

Thank you for reviewing this PR :smile_cat: 

p.s.
I compared the generated MIR and ASM from https://play.rust-lang.org with/without `const`.
```rust
// Removing 'const' specifier does not change output of generated MIR & ASM :)
pub const fn new() -> Vec<i64> {
    Vec::new()
}

/* ASM OUTPUT
playground::new:
	movq	%rdi, %rax
	movq	$8, (%rdi)
	xorps	%xmm0, %xmm0
	movups	%xmm0, 8(%rdi)
	retq
*/

/* MIR OUTPUT
// WARNING: This output format is intended for human consumers only
// and is subject to change without notice. Knock yourself out.
fn new() -> std::vec::Vec<i64> {
    let mut _0: std::vec::Vec<i64>;      // return place in scope 0 at src/lib.rs:1:17: 1:25

    bb0: {
        _0 = const std::vec::Vec::<i64>::new() -> bb1; // bb0[0]: scope 0 at src/lib.rs:2:5: 2:15
                                         // ty::Const
                                         // + ty: fn() -> std::vec::Vec<i64> {std::vec::Vec::<i64>::new}
                                         // + val: Value(Scalar(<ZST>))
                                         // mir::Constant
                                         // + span: src/lib.rs:2:5: 2:13
                                         // + user_ty: UserType(0)
                                         // + literal: Const { ty: fn() -> std::vec::Vec<i64> {std::vec::Vec::<i64>::new}, val: Value(Scalar(<ZST>)) }
    }

    bb1: {
        return;                          // bb1[0]: scope 0 at src/lib.rs:3:2: 3:2
    }
}
*/
```