### PR TITLE
Use newer const fn features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [1.46.0, stable, beta, nightly]
+        rust: [1.56.1, stable, beta, nightly]
     steps:
       - uses: actions/checkout@v2
       - uses: hecrj/setup-rust-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [1.41.1, stable, beta, nightly]
+        rust: [1.46.0, stable, beta, nightly]
     steps:
       - uses: actions/checkout@v2
       - uses: hecrj/setup-rust-action@v1

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ ascii = { version = "1.1", default-features = false, features = ["alloc"] }
 
 ## Minimum supported Rust version
 
-The minimum Rust version for 1.1.\* releases is 1.41.1.
+The minimum Rust version for 1.2.\* releases is 1.46.0.
 Later 1.y.0 releases might require newer Rust versions, but the three most
 recent stable releases at the time of publishing will always be supported.  
 For example this means that if the current stable Rust version is 1.70 when
-ascii 1.2.0 is released, then ascii 1.2.\* will not require a newer
+ascii 1.3.0 is released, then ascii 1.3.\* will not require a newer
 Rust version than 1.68.
 
 ## History

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ ascii = { version = "1.1", default-features = false, features = ["alloc"] }
 
 ## Minimum supported Rust version
 
-The minimum Rust version for 1.2.\* releases is 1.46.0.
+The minimum Rust version for 1.2.\* releases is 1.56.1.
 Later 1.y.0 releases might require newer Rust versions, but the three most
 recent stable releases at the time of publishing will always be supported.  
 For example this means that if the current stable Rust version is 1.70 when

--- a/src/ascii_char.rs
+++ b/src/ascii_char.rs
@@ -360,6 +360,32 @@ impl AsciiChar {
         ALL[ch as usize]
     }
 
+    /// Create an `AsciiChar` from a `char`, in a `const fn` way.
+    ///
+    /// Within non-`const fn` functions the more general
+    /// [`from_ascii()`](#method.from_ascii) should be used instead.
+    ///
+    /// # Examples
+    /// ```
+    /// # use ascii::AsciiChar;
+    /// assert!(AsciiChar::try_new('-').is_ok());
+    /// assert!(AsciiChar::try_new('—').is_err());
+    /// assert_eq!(AsciiChar::try_new('\x7f'), Ok(AsciiChar::DEL));
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Fails for non-ASCII characters.
+    #[inline]
+    pub const fn try_new(ch: char) -> Result<Self, ToAsciiCharError> {
+        unsafe {
+            match ch as u32 {
+                0..=127 => Ok(mem::transmute(ch as u8)),
+                _ => Err(ToAsciiCharError(())),
+            }
+        }
+    }
+
     /// Constructs an ASCII character from a `u8`, `char` or other character
     /// type without any checks.
     ///

--- a/src/ascii_char.rs
+++ b/src/ascii_char.rs
@@ -411,7 +411,7 @@ impl AsciiChar {
     #[inline]
     #[must_use]
     pub const fn is_alphabetic(self) -> bool {
-        (self.to_not_upper() >= b'a') & (self.to_not_upper() <= b'z')
+        (self.to_not_upper() >= b'a') && (self.to_not_upper() <= b'z')
     }
 
     /// Check if the character is a letter (a-z, A-Z).
@@ -457,14 +457,14 @@ impl AsciiChar {
     #[inline]
     #[must_use]
     pub const fn is_ascii_digit(&self) -> bool {
-        (*self as u8 >= b'0') & (*self as u8 <= b'9')
+        (*self as u8 >= b'0') && (*self as u8 <= b'9')
     }
 
     /// Check if the character is a letter or number
     #[inline]
     #[must_use]
     pub const fn is_alphanumeric(self) -> bool {
-        self.is_alphabetic() | self.is_ascii_digit()
+        self.is_alphabetic() || self.is_ascii_digit()
     }
 
     /// Check if the character is a letter or number
@@ -491,7 +491,7 @@ impl AsciiChar {
     #[inline]
     #[must_use]
     pub const fn is_ascii_blank(&self) -> bool {
-        (*self as u8 == b' ') | (*self as u8 == b'\t')
+        (*self as u8 == b' ') || (*self as u8 == b'\t')
     }
 
     /// Check if the character one of ' ', '\t', '\n', '\r',
@@ -500,7 +500,7 @@ impl AsciiChar {
     #[must_use]
     pub const fn is_whitespace(self) -> bool {
         let b = self as u8;
-        self.is_ascii_blank() | (b == b'\n') | (b == b'\r') | (b == 0x0b) | (b == 0x0c)
+        self.is_ascii_blank() || (b == b'\n') || (b == b'\r') || (b == 0x0b) || (b == 0x0c)
     }
 
     /// Check if the character is a ' ', '\t', '\n', '\r' or '\0xc' (form feed).
@@ -510,9 +510,9 @@ impl AsciiChar {
     #[must_use]
     pub const fn is_ascii_whitespace(&self) -> bool {
         self.is_ascii_blank()
-            | (*self as u8 == b'\n')
-            | (*self as u8 == b'\r')
-            | (*self as u8 == 0x0c/*form feed*/)
+            || (*self as u8 == b'\n')
+            || (*self as u8 == b'\r')
+            || (*self as u8 == 0x0c/*form feed*/)
     }
 
     /// Check if the character is a control character
@@ -530,7 +530,7 @@ impl AsciiChar {
     #[inline]
     #[must_use]
     pub const fn is_ascii_control(&self) -> bool {
-        ((*self as u8) < b' ') | (*self as u8 == 127)
+        ((*self as u8) < b' ') || (*self as u8 == 127)
     }
 
     /// Checks if the character is printable (except space)
@@ -624,7 +624,7 @@ impl AsciiChar {
     #[inline]
     #[must_use]
     pub const fn is_ascii_punctuation(&self) -> bool {
-        self.is_ascii_graphic() & !self.is_alphanumeric()
+        self.is_ascii_graphic() && !self.is_alphanumeric()
     }
 
     /// Checks if the character is a valid hex digit
@@ -641,7 +641,7 @@ impl AsciiChar {
     #[inline]
     #[must_use]
     pub const fn is_ascii_hexdigit(&self) -> bool {
-        self.is_ascii_digit() | ((*self as u8 | 0x20_u8).wrapping_sub(b'a') < 6)
+        self.is_ascii_digit() || ((*self as u8 | 0x20u8).wrapping_sub(b'a') < 6)
     }
 
     /// Unicode has printable versions of the ASCII control codes, like '␛'.
@@ -728,7 +728,7 @@ impl AsciiChar {
     #[must_use]
     pub const fn eq_ignore_ascii_case(&self, other: &Self) -> bool {
         (self.as_byte() == other.as_byte())
-            | (self.is_alphabetic() & (self.to_not_upper() == other.to_not_upper()))
+            || (self.is_alphabetic() && (self.to_not_upper() == other.to_not_upper()))
     }
 }
 

--- a/src/ascii_str.rs
+++ b/src/ascii_str.rs
@@ -48,17 +48,17 @@ impl AsciiStr {
     /// Converts `&self` to a `&str` slice.
     #[inline]
     #[must_use]
-    pub fn as_str(&self) -> &str {
+    pub const fn as_str(&self) -> &str {
         // SAFETY: All variants of `AsciiChar` are valid bytes for a `str`.
-        unsafe { &*(self as *const AsciiStr as *const str) }
+        unsafe { mem::transmute(self) }
     }
 
     /// Converts `&self` into a byte slice.
     #[inline]
     #[must_use]
-    pub fn as_bytes(&self) -> &[u8] {
+    pub const fn as_bytes(&self) -> &[u8] {
         // SAFETY: All variants of `AsciiChar` are valid `u8`, given they're `repr(u8)`.
-        unsafe { &*(self as *const AsciiStr as *const [u8]) }
+        unsafe { mem::transmute(self) }
     }
 
     /// Returns the entire string as slice of `AsciiChar`s.

--- a/src/ascii_str.rs
+++ b/src/ascii_str.rs
@@ -2,7 +2,7 @@
 use alloc::borrow::ToOwned;
 #[cfg(feature = "alloc")]
 use alloc::boxed::Box;
-use core::fmt;
+use core::{fmt, mem};
 use core::ops::{Index, IndexMut};
 use core::ops::{Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive};
 use core::slice::{self, Iter, IterMut, SliceIndex};
@@ -28,6 +28,23 @@ pub struct AsciiStr {
 }
 
 impl AsciiStr {
+    /// Coerces into an `AsciiStr` slice.
+    ///
+    /// # Examples
+    /// ```
+    /// # use ascii::{AsciiChar, AsciiStr};
+    /// const HELLO: &AsciiStr = AsciiStr::new(
+    ///     &[AsciiChar::H, AsciiChar::e, AsciiChar::l, AsciiChar::l, AsciiChar::o]
+    /// );
+    ///
+    /// assert_eq!(HELLO.as_str(), "Hello");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn new(s: &[AsciiChar]) -> &Self {
+        unsafe { mem::transmute(s) }
+    }
+
     /// Converts `&self` to a `&str` slice.
     #[inline]
     #[must_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //!
 //! # Minimum supported Rust version
 //!
-//! The minimum Rust version for 1.2.\* releases is 1.46.0.
+//! The minimum Rust version for 1.2.\* releases is 1.56.1.
 //! Later 1.y.0 releases might require newer Rust versions, but the three most
 //! recent stable releases at the time of publishing will always be supported.  
 //! For example this means that if the current stable Rust version is 1.70 when

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,11 +15,11 @@
 //!
 //! # Minimum supported Rust version
 //!
-//! The minimum Rust version for 1.1.\* releases is 1.41.1.
+//! The minimum Rust version for 1.2.\* releases is 1.46.0.
 //! Later 1.y.0 releases might require newer Rust versions, but the three most
 //! recent stable releases at the time of publishing will always be supported.  
 //! For example this means that if the current stable Rust version is 1.70 when
-//! ascii 1.2.0 is released, then ascii 1.2.\* will not require a newer
+//! ascii 1.3.0 is released, then ascii 1.3.\* will not require a newer
 //! Rust version than 1.68.
 //!
 //! # History


### PR DESCRIPTION
Existing methods made `const fn`:
* ~`AsciiStr::len()`~ (done in #95)
* ~`AsciiStr::is_empty()`~ (done in #95)
* `AsciiStr::as_str()`
* `AsciiStr::as_bytes()`
* `AsciiStr::trim()`
* `AsciiStr::trim_left()`
* `AsciiStr::trim_right()`
* `AsciiChar::from_ascii_unchecked()`
* `AsciiChar::as_printable_char()`
* ~`AsciiChar::is_digit()`~ (postponed)

New methods:
* `AsciiStr::new([AsciiChar])`
* `AsciiStr::from_ascii_bytes()`
* `AsciiStr::from_ascii_str()`
* `AsciiChar::try_new(char)`

Also switch back to `&&` and `||` in many methods, ~and `panic!()` in `AsciiChar::new()`~ (postponed).

This increases MSRV ~all the way to 1.57~ 1.56.