### PR TITLE
Replace `AsciiChar::SOX` with associated constant STX`

### DIFF
--- a/src/ascii_char.rs
+++ b/src/ascii_char.rs
@@ -13,7 +13,10 @@ pub enum AsciiChar {
     Null = 0,
     /// [Start Of Heading](http://en.wikipedia.org/wiki/Start_of_Heading)
     SOH = 1,
-    /// [Start Of teXt](http://en.wikipedia.org/wiki/Start_of_Text)
+    #[allow(clippy::doc_markdown)]
+    /// [Start of TeXt](http://en.wikipedia.org/wiki/Start_of_Text)
+    #[doc(hidden)]
+    #[deprecated(since="1.2.0", note="Replaced with AsciiChar::STX which is the correct name for this variant.")]
     SOX = 2,
     /// [End of TeXt](http://en.wikipedia.org/wiki/End-of-Text_character)
     ETX = 3,
@@ -278,6 +281,13 @@ pub enum AsciiChar {
 }
 
 impl AsciiChar {
+    /// [Start of TeXt](http://en.wikipedia.org/wiki/Start_of_Text)
+    ///
+    /// (It's an associated constant instead of a variant because
+    ///  the variant for it has an incorrect name.)
+    #[allow(deprecated, clippy::doc_markdown)]
+    pub const STX: AsciiChar = AsciiChar::SOX;
+
     /// Constructs an ASCII character from a `u8`, `char` or other character type.
     ///
     /// # Errors
@@ -337,7 +347,7 @@ impl AsciiChar {
 
         #[rustfmt::skip]
         const ALL: [AsciiChar; 128] = [
-            Null, SOH, SOX, ETX, EOT, ENQ, ACK, Bell,
+            Null, SOH, AsciiChar::STX, ETX, EOT, ENQ, ACK, Bell,
             BackSpace, Tab, LineFeed, VT, FF, CarriageReturn, SI, SO,
             DLE, DC1, DC2, DC3, DC4, NAK, SYN, ETB,
             CAN, EM, SUB, ESC, FS, GS, RS, US,

--- a/tests.rs
+++ b/tests.rs
@@ -28,6 +28,13 @@ fn to_ascii() {
 }
 
 #[test]
+fn deprecated_variant() {
+    #![allow(deprecated)]
+    use AsciiChar::*;
+    assert_eq!(AsciiChar::STX, SOX);
+}
+
+#[test]
 #[cfg(feature = "std")]
 fn into_ascii() {
     let arr = [AsciiChar::ParenOpen, AsciiChar::Space, AsciiChar::Semicolon];


### PR DESCRIPTION
`SOX` is the wrong name. for this character.

Renaming the variant and adding `SOX` as associated constant
would break `use`s of it. both explicit and glob imports.

Fixes #78.