### PR TITLE
allow "bindings_with_variant_name" lint where necessary (fixes compiling tests with Rust 1.68.0+)

### DIFF
--- a/src/ascii_char.rs
+++ b/src/ascii_char.rs
@@ -295,6 +295,7 @@ impl AsciiChar {
     ///
     /// # Example
     /// ```
+    /// # #![allow(bindings_with_variant_name)]
     /// # use ascii::AsciiChar;
     /// let a = AsciiChar::from_ascii('g').unwrap();
     /// assert_eq!(a.as_char(), 'g');

--- a/src/ascii_string.rs
+++ b/src/ascii_string.rs
@@ -308,6 +308,7 @@ impl AsciiString {
     ///
     /// # Examples
     /// ```
+    /// # #![allow(bindings_with_variant_name)]
     /// # use ascii::AsciiString;
     /// let mut s = AsciiString::from_ascii("foo").unwrap();
     /// assert_eq!(s.pop().map(|c| c.as_char()), Some('o'));


### PR DESCRIPTION
Rust 1.68.0 promoted the `bindings_with_variant_name` lint to "deny-by-default" :
https://github.com/rust-lang/rust/blob/1.68.0/RELEASES.md#compiler

Allowing this in a few places (i.e. adding `#[allow(bindings_with_variant_name)]` attributes in two doctest snippets) fixes the following compilation errors when running `cargo test` on Rust 1.68.0 or later:

```
---- src/ascii_char.rs - ascii_char::AsciiChar::from_ascii (line 297) stdout ----
error[E0170]: pattern binding `a` is named the same as one of the variants of the type `ascii::AsciiChar`
 --> src/ascii_char.rs:299:5
  |
5 | let a = AsciiChar::from_ascii('g').unwrap();
  |     ^
  |
  = note: `#[deny(bindings_with_variant_name)]` on by default

error: aborting due to previous error

For more information about this error, try `rustc --explain E0170`.
Couldn't compile the test.
---- src/ascii_string.rs - ascii_string::AsciiString::pop (line 310) stdout ----
error[E0170]: pattern binding `c` is named the same as one of the variants of the type `ascii::AsciiChar`
 --> src/ascii_string.rs:313:25
  |
6 | assert_eq!(s.pop().map(|c| c.as_char()), Some('o'));
  |                         ^
  |
  = note: `#[deny(bindings_with_variant_name)]` on by default

error[E0170]: pattern binding `c` is named the same as one of the variants of the type `ascii::AsciiChar`
 --> src/ascii_string.rs:314:25
  |
7 | assert_eq!(s.pop().map(|c| c.as_char()), Some('o'));
  |                         ^

error[E0170]: pattern binding `c` is named the same as one of the variants of the type `ascii::AsciiChar`
 --> src/ascii_string.rs:315:25
  |
8 | assert_eq!(s.pop().map(|c| c.as_char()), Some('f'));
  |                         ^

error: aborting due to 3 previous errors

For more information about this error, try `rustc --explain E0170`.
Couldn't compile the test.

failures:
    src/ascii_char.rs - ascii_char::AsciiChar::from_ascii (line 297)
    src/ascii_string.rs - ascii_string::AsciiString::pop (line 310)

test result: FAILED. 51 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.66s

error: doctest failed, to rerun pass `--doc`
```