### PR TITLE
Fix & ignore new lints

### DIFF
--- a/src/ascii_char.rs
+++ b/src/ascii_char.rs
@@ -794,8 +794,8 @@ macro_rules! impl_into_partial_eq_ord {
     ($wider:ty, $to_wider:expr) => {
         impl From<AsciiChar> for $wider {
             #[inline]
-            fn from(a: AsciiChar) -> $wider {
-                $to_wider(a)
+            fn from(ascii: AsciiChar) -> $wider {
+                $to_wider(ascii)
             }
         }
         impl PartialEq<$wider> for AsciiChar {

--- a/src/ascii_str.rs
+++ b/src/ascii_str.rs
@@ -1603,12 +1603,12 @@ mod tests {
                 assert_eq!(asciis.size_hint(), strs.size_hint());
                 let (a, s) = (asciis.next(), strs.next());
                 assert_eq!(a, s);
-                if a == None {
+                if a.is_none() {
                     break;
                 }
             }
             // test fusedness if str's version is fused
-            if strs.next() == None {
+            if strs.next().is_none() {
                 assert_eq!(asciis.next(), None);
             }
         }

--- a/src/ascii_string.rs
+++ b/src/ascii_string.rs
@@ -474,14 +474,14 @@ impl_eq! { AsciiString, &str }
 impl Borrow<AsciiStr> for AsciiString {
     #[inline]
     fn borrow(&self) -> &AsciiStr {
-        &**self
+        self
     }
 }
 
 impl BorrowMut<AsciiStr> for AsciiString {
     #[inline]
     fn borrow_mut(&mut self) -> &mut AsciiStr {
-        &mut **self
+        self
     }
 }
 
@@ -594,7 +594,7 @@ impl<'a> From<&'a AsciiStr> for Cow<'a, AsciiStr> {
 impl AsRef<AsciiStr> for AsciiString {
     #[inline]
     fn as_ref(&self) -> &AsciiStr {
-        &**self
+        self
     }
 }
 
@@ -1046,6 +1046,24 @@ mod tests {
         let sparkle_heart_bytes = [240, 159, 146, 150];
         let sparkle_heart = str::from_utf8(&sparkle_heart_bytes).unwrap();
         assert!(fmt::write(&mut s2, format_args!("{}", sparkle_heart)).is_err());
+    }
+
+    #[test]
+    fn as_ref() {
+        let mut s = AsciiString::from_ascii(&[b'a', b'b', b'c'][..]).unwrap();
+        let as_ref: &AsciiStr = s.as_ref();
+        assert_eq!(as_ref, AsciiStr::from_ascii_str("abc").unwrap());
+        let as_mut: &mut AsciiStr = s.as_mut();
+        assert_eq!(as_mut.len(), s.len());
+    }
+
+    #[test]
+    fn borrow() {
+        let mut s = AsciiString::from_ascii(&[b'1', b'2', b'3'][..]).unwrap();
+        let borrowed: &AsciiStr = &s;
+        assert_eq!(borrowed, AsciiStr::from_ascii_str("123").unwrap());
+        let borrowed: &mut AsciiStr = &mut s;
+        assert_eq!(borrowed.len(), s.len());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,10 +47,16 @@
 #![allow(clippy::shadow_unrelated, clippy::shadow_reuse, clippy::shadow_same)]
 // A `if let` / `else` sometimes looks better than using iterator adaptors
 #![allow(clippy::option_if_let_else)]
+// 
+#![allow(clippy::uninlined_format_args)]
+// #[default]-on-enum-variant was added in 1.66.0.
+#![allow(clippy::derivable_impls)]
 // In tests, we're fine with indexing, since a panic is a failure.
 #![cfg_attr(test, allow(clippy::indexing_slicing))]
 // for compatibility with methods on char and u8
 #![allow(clippy::trivially_copy_pass_by_ref)]
+// requires 1.65, might not be worth it
+#![allow(clippy::manual_let_else)]
 // In preparation for feature `unsafe_block_in_unsafe_fn` (https://github.com/rust-lang/rust/issues/71668)
 #![allow(unused_unsafe)]
 


### PR DESCRIPTION
Including one from rustc.

Test that the suggestions for clippy::explicit_auto_deref doesn't cause infinite recursion.