### PR TITLE
Better error message for AsciiChar::new

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ name = "ascii"
 readme = "README.md"
 repository = "https://github.com/tomprogrammer/rust-ascii"
 version = "1.1.0"
+rust-version = "1.57.0"
 
 [dependencies]
 serde = { version = "1.0.25", optional = true }

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ ascii = { version = "1.1", default-features = false, features = ["alloc"] }
 
 ## Minimum supported Rust version
 
-The minimum Rust version for 1.2.\* releases is 1.56.1.
+The minimum Rust version for 1.2.\* releases is 1.57.0.
 Later 1.y.0 releases might require newer Rust versions, but the three most
 recent stable releases at the time of publishing will always be supported.  
 For example this means that if the current stable Rust version is 1.70 when

--- a/src/ascii_char.rs
+++ b/src/ascii_char.rs
@@ -341,34 +341,10 @@ impl AsciiChar {
     /// current limitations of `const fn`.
     #[must_use]
     pub const fn new(ch: char) -> AsciiChar {
-        // It's restricted to this function, and without it
-        // we'd need to specify `AsciiChar::` or `Self::` 128 times.
-        #[allow(clippy::enum_glob_use)]
-        use AsciiChar::*;
-
-        #[rustfmt::skip]
-        const ALL: [AsciiChar; 128] = [
-            Null, SOH, AsciiChar::STX, ETX, EOT, ENQ, ACK, Bell,
-            BackSpace, Tab, LineFeed, VT, FF, CarriageReturn, SI, SO,
-            DLE, DC1, DC2, DC3, DC4, NAK, SYN, ETB,
-            CAN, EM, SUB, ESC, FS, GS, RS, US,
-            Space, Exclamation, Quotation, Hash, Dollar, Percent, Ampersand, Apostrophe,
-            ParenOpen, ParenClose, Asterisk, Plus, Comma, Minus, Dot, Slash,
-            _0, _1, _2, _3, _4, _5, _6, _7,
-            _8, _9, Colon, Semicolon, LessThan, Equal, GreaterThan, Question,
-            At, A, B, C, D, E, F, G,
-            H, I, J, K, L, M, N, O,
-            P, Q, R, S, T, U, V, W,
-            X, Y, Z, BracketOpen, BackSlash, BracketClose, Caret, UnderScore,
-            Grave, a, b, c, d, e, f, g,
-            h, i, j, k, l, m, n, o,
-            p, q, r, s, t, u, v, w,
-            x, y, z, CurlyBraceOpen, VerticalBar, CurlyBraceClose, Tilde, DEL,
-		];
-
-        // We want to slice here and detect `const_err` from rustc if the slice is invalid
-        #[allow(clippy::indexing_slicing)]
-        ALL[ch as usize]
+        match Self::try_new(ch) {
+            Ok(ch) => ch,
+            Err(_) => panic!("{}", ERRORMSG_CHAR),
+        }
     }
 
     /// Create an `AsciiChar` from a `char`, in a `const fn` way.
@@ -389,11 +365,10 @@ impl AsciiChar {
     /// Fails for non-ASCII characters.
     #[inline]
     pub const fn try_new(ch: char) -> Result<Self, ToAsciiCharError> {
-        unsafe {
-            match ch as u32 {
-                0..=127 => Ok(mem::transmute(ch as u8)),
-                _ => Err(ToAsciiCharError(())),
-            }
+        if ch.is_ascii() {
+            Ok(unsafe { Self::from_ascii_unchecked(ch as u8) })
+        } else {
+            Err(ToAsciiCharError(()))
         }
     }
 

--- a/src/ascii_char.rs
+++ b/src/ascii_char.rs
@@ -794,8 +794,8 @@ macro_rules! impl_into_partial_eq_ord {
     ($wider:ty, $to_wider:expr) => {
         impl From<AsciiChar> for $wider {
             #[inline]
-            fn from(a: AsciiChar) -> $wider {
-                $to_wider(a)
+            fn from(ch: AsciiChar) -> $wider {
+                $to_wider(ch)
             }
         }
         impl PartialEq<$wider> for AsciiChar {


### PR DESCRIPTION
- Fix bindings_with_variant_name error
- Better error message for AsciiChar::new
