### PR TITLE
fix: `impl<'a> From<AsciiString> for Cow<'a, AsciiStr>`

### DIFF
--- a/src/ascii_string.rs
+++ b/src/ascii_string.rs
@@ -579,8 +579,8 @@ impl<'a> From<Cow<'a, AsciiStr>> for AsciiString {
     }
 }
 
-impl From<AsciiString> for Cow<'static, AsciiStr> {
-    fn from(string: AsciiString) -> Cow<'static, AsciiStr> {
+impl<'a> From<AsciiString> for Cow<'a, AsciiStr> {
+    fn from(string: AsciiString) -> Cow<'a, AsciiStr> {
         Cow::Owned(string)
     }
 }


### PR DESCRIPTION
Fixes #110

Modify the implementation of `From<AsciiString>` for `Cow<'a, AsciiStr>`.

* Change `impl From<AsciiString> for Cow<'static, AsciiStr>` to `impl<'a> From<AsciiString> for Cow<'a, AsciiStr>` in `src/ascii_string.rs`
* Broaden the conversion abilities by making it generic over any lifetime `'a`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tomprogrammer/rust-ascii/pull/111?shareId=0fb373dd-75bf-4d53-8b3e-8a3c4f0969d9).